### PR TITLE
Implement customer, manufacturing, purchases, and analytics modules

### DIFF
--- a/backend/Functions/CustomerManufacturingFunctions.cs
+++ b/backend/Functions/CustomerManufacturingFunctions.cs
@@ -1,0 +1,333 @@
+using System.Net;
+using System.Text.Json;
+using backend.Models;
+using backend.Services;
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Azure.Functions.Worker.Http;
+
+namespace backend.Functions;
+
+public sealed class CustomerManufacturingFunctions
+{
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true,
+    };
+
+    private readonly ICustomerManufacturingSqlService _service;
+
+    public CustomerManufacturingFunctions(ICustomerManufacturingSqlService service)
+    {
+        _service = service;
+    }
+
+    [Function("GetCustomers")]
+    public async Task<HttpResponseData> GetCustomers(
+        [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "customers")] HttpRequestData req)
+    {
+        var query = System.Web.HttpUtility.ParseQueryString(req.Url.Query);
+        var search = query["search"];
+        var limit = ParseInt(query["limit"], 100);
+        var offset = ParseInt(query["offset"], 0);
+
+        var customers = await _service.GetCustomersAsync(search, limit, offset, req.FunctionContext.CancellationToken);
+        var response = req.CreateResponse(HttpStatusCode.OK);
+        await response.WriteAsJsonAsync(customers);
+        return response;
+    }
+
+    [Function("CreateCustomer")]
+    public async Task<HttpResponseData> CreateCustomer(
+        [HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = "customers")] HttpRequestData req)
+    {
+        var body = await DeserializeBodyAsync<CustomerUpsertRequest>(req);
+        if (body is null)
+        {
+            return await BadRequestAsync(req, "Invalid customer payload.");
+        }
+
+        try
+        {
+            var created = await _service.CreateCustomerAsync(body, req.FunctionContext.CancellationToken);
+            var response = req.CreateResponse(HttpStatusCode.Created);
+            await response.WriteAsJsonAsync(created);
+            return response;
+        }
+        catch (ArgumentException ex)
+        {
+            return await BadRequestAsync(req, ex.Message);
+        }
+    }
+
+    [Function("GetCustomerById")]
+    public async Task<HttpResponseData> GetCustomerById(
+        [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "customers/{id:guid}")] HttpRequestData req,
+        Guid id)
+    {
+        var customer = await _service.GetCustomerByIdAsync(id, req.FunctionContext.CancellationToken);
+        if (customer is null)
+        {
+            return await NotFoundAsync(req, "Customer not found.");
+        }
+
+        var response = req.CreateResponse(HttpStatusCode.OK);
+        await response.WriteAsJsonAsync(customer);
+        return response;
+    }
+
+    [Function("UpdateCustomer")]
+    public async Task<HttpResponseData> UpdateCustomer(
+        [HttpTrigger(AuthorizationLevel.Anonymous, "put", Route = "customers/{id:guid}")] HttpRequestData req,
+        Guid id)
+    {
+        var body = await DeserializeBodyAsync<CustomerUpsertRequest>(req);
+        if (body is null)
+        {
+            return await BadRequestAsync(req, "Invalid customer payload.");
+        }
+
+        try
+        {
+            var updated = await _service.UpdateCustomerAsync(id, body, req.FunctionContext.CancellationToken);
+            if (updated is null)
+            {
+                return await NotFoundAsync(req, "Customer not found.");
+            }
+
+            var response = req.CreateResponse(HttpStatusCode.OK);
+            await response.WriteAsJsonAsync(updated);
+            return response;
+        }
+        catch (ArgumentException ex)
+        {
+            return await BadRequestAsync(req, ex.Message);
+        }
+    }
+
+    [Function("DeleteCustomer")]
+    public async Task<HttpResponseData> DeleteCustomer(
+        [HttpTrigger(AuthorizationLevel.Anonymous, "delete", Route = "customers/{id:guid}")] HttpRequestData req,
+        Guid id)
+    {
+        var deleted = await _service.DeleteCustomerAsync(id, req.FunctionContext.CancellationToken);
+        if (!deleted)
+        {
+            return await NotFoundAsync(req, "Customer not found.");
+        }
+
+        var response = req.CreateResponse(HttpStatusCode.OK);
+        await response.WriteAsJsonAsync(new { success = true });
+        return response;
+    }
+
+    [Function("AddCustomerNote")]
+    public async Task<HttpResponseData> AddCustomerNote(
+        [HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = "customers/{id:guid}/notes")] HttpRequestData req,
+        Guid id)
+    {
+        var body = await DeserializeBodyAsync<CustomerNoteRequest>(req);
+        if (body is null || string.IsNullOrWhiteSpace(body.Note))
+        {
+            return await BadRequestAsync(req, "Note content is required.");
+        }
+
+        var appended = await _service.AppendCustomerNoteAsync(id, body.Note, req.FunctionContext.CancellationToken);
+        if (!appended)
+        {
+            return await NotFoundAsync(req, "Customer not found.");
+        }
+
+        var customer = await _service.GetCustomerByIdAsync(id, req.FunctionContext.CancellationToken);
+        var response = req.CreateResponse(HttpStatusCode.OK);
+        await response.WriteAsJsonAsync(new
+        {
+            success = true,
+            customer,
+        });
+        return response;
+    }
+
+    [Function("GetCustomerActivity")]
+    public async Task<HttpResponseData> GetCustomerActivity(
+        [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "customers/{id:guid}/activity")] HttpRequestData req,
+        Guid id)
+    {
+        var query = System.Web.HttpUtility.ParseQueryString(req.Url.Query);
+        var limit = ParseInt(query["limit"], 100);
+
+        var customer = await _service.GetCustomerByIdAsync(id, req.FunctionContext.CancellationToken);
+        if (customer is null)
+        {
+            return await NotFoundAsync(req, "Customer not found.");
+        }
+
+        var activity = await _service.GetCustomerActivityAsync(id, limit, req.FunctionContext.CancellationToken);
+        var response = req.CreateResponse(HttpStatusCode.OK);
+        await response.WriteAsJsonAsync(activity);
+        return response;
+    }
+
+    [Function("GetManufacturingProjects")]
+    public async Task<HttpResponseData> GetManufacturingProjects(
+        [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "manufacturing")] HttpRequestData req)
+    {
+        var query = System.Web.HttpUtility.ParseQueryString(req.Url.Query);
+        var search = query["search"];
+        var status = query["status"];
+        var limit = ParseInt(query["limit"], 100);
+        var offset = ParseInt(query["offset"], 0);
+
+        Guid? customerId = null;
+        if (!string.IsNullOrWhiteSpace(query["customer_id"]))
+        {
+            if (!Guid.TryParse(query["customer_id"], out var parsedCustomerId))
+            {
+                return await BadRequestAsync(req, "Invalid customer_id query value.");
+            }
+
+            customerId = parsedCustomerId;
+        }
+
+        var records = await _service.GetManufacturingProjectsAsync(
+            search,
+            status,
+            customerId,
+            limit,
+            offset,
+            req.FunctionContext.CancellationToken);
+
+        var response = req.CreateResponse(HttpStatusCode.OK);
+        await response.WriteAsJsonAsync(records);
+        return response;
+    }
+
+    [Function("CreateManufacturingProject")]
+    public async Task<HttpResponseData> CreateManufacturingProject(
+        [HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = "manufacturing")] HttpRequestData req)
+    {
+        var body = await DeserializeBodyAsync<ManufacturingProjectUpsertRequest>(req);
+        if (body is null)
+        {
+            return await BadRequestAsync(req, "Invalid manufacturing payload.");
+        }
+
+        try
+        {
+            var created = await _service.CreateManufacturingProjectAsync(body, req.FunctionContext.CancellationToken);
+            var response = req.CreateResponse(HttpStatusCode.Created);
+            await response.WriteAsJsonAsync(created);
+            return response;
+        }
+        catch (ArgumentException ex)
+        {
+            return await BadRequestAsync(req, ex.Message);
+        }
+    }
+
+    [Function("GetManufacturingProjectById")]
+    public async Task<HttpResponseData> GetManufacturingProjectById(
+        [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "manufacturing/{id:int}")] HttpRequestData req,
+        int id)
+    {
+        var record = await _service.GetManufacturingProjectByIdAsync(id, req.FunctionContext.CancellationToken);
+        if (record is null)
+        {
+            return await NotFoundAsync(req, "Manufacturing project not found.");
+        }
+
+        var response = req.CreateResponse(HttpStatusCode.OK);
+        await response.WriteAsJsonAsync(record);
+        return response;
+    }
+
+    [Function("UpdateManufacturingProject")]
+    public async Task<HttpResponseData> UpdateManufacturingProject(
+        [HttpTrigger(AuthorizationLevel.Anonymous, "put", Route = "manufacturing/{id:int}")] HttpRequestData req,
+        int id)
+    {
+        var body = await DeserializeBodyAsync<ManufacturingProjectUpsertRequest>(req);
+        if (body is null)
+        {
+            return await BadRequestAsync(req, "Invalid manufacturing payload.");
+        }
+
+        try
+        {
+            var updated = await _service.UpdateManufacturingProjectAsync(id, body, req.FunctionContext.CancellationToken);
+            if (updated is null)
+            {
+                return await NotFoundAsync(req, "Manufacturing project not found.");
+            }
+
+            var response = req.CreateResponse(HttpStatusCode.OK);
+            await response.WriteAsJsonAsync(updated);
+            return response;
+        }
+        catch (ArgumentException ex)
+        {
+            return await BadRequestAsync(req, ex.Message);
+        }
+    }
+
+    [Function("DeleteManufacturingProject")]
+    public async Task<HttpResponseData> DeleteManufacturingProject(
+        [HttpTrigger(AuthorizationLevel.Anonymous, "delete", Route = "manufacturing/{id:int}")] HttpRequestData req,
+        int id)
+    {
+        var deleted = await _service.DeleteManufacturingProjectAsync(id, req.FunctionContext.CancellationToken);
+        if (!deleted)
+        {
+            return await NotFoundAsync(req, "Manufacturing project not found.");
+        }
+
+        var response = req.CreateResponse(HttpStatusCode.OK);
+        await response.WriteAsJsonAsync(new { success = true });
+        return response;
+    }
+
+    [Function("GetBusinessAnalytics")]
+    public async Task<HttpResponseData> GetBusinessAnalytics(
+        [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "analytics")] HttpRequestData req)
+    {
+        var analytics = await _service.GetAnalyticsAsync(req.FunctionContext.CancellationToken);
+        var response = req.CreateResponse(HttpStatusCode.OK);
+        await response.WriteAsJsonAsync(analytics);
+        return response;
+    }
+
+    private static async Task<T?> DeserializeBodyAsync<T>(HttpRequestData req)
+    {
+        try
+        {
+            return await JsonSerializer.DeserializeAsync<T>(req.Body, JsonOptions);
+        }
+        catch
+        {
+            return default;
+        }
+    }
+
+    private static async Task<HttpResponseData> BadRequestAsync(HttpRequestData req, string message)
+    {
+        var response = req.CreateResponse(HttpStatusCode.BadRequest);
+        await response.WriteAsJsonAsync(new { error = message });
+        return response;
+    }
+
+    private static async Task<HttpResponseData> NotFoundAsync(HttpRequestData req, string message)
+    {
+        var response = req.CreateResponse(HttpStatusCode.NotFound);
+        await response.WriteAsJsonAsync(new { error = message });
+        return response;
+    }
+
+    private static int ParseInt(string? value, int fallback)
+    {
+        if (int.TryParse(value, out var parsed))
+        {
+            return parsed;
+        }
+
+        return fallback;
+    }
+}

--- a/backend/Models/CustomerManufacturingModels.cs
+++ b/backend/Models/CustomerManufacturingModels.cs
@@ -1,0 +1,264 @@
+namespace backend.Models;
+
+public static class ManufacturingStatuses
+{
+    public const string Approved = "approved";
+    public const string SentToCraftsman = "sent_to_craftsman";
+    public const string InternalSettingQc = "internal_setting_qc";
+    public const string DiamondSorting = "diamond_sorting";
+    public const string StoneSetting = "stone_setting";
+    public const string Plating = "plating";
+    public const string FinalPieceQc = "final_piece_qc";
+    public const string CompletePiece = "complete_piece";
+    public const string ReadyForSale = "ready_for_sale";
+    public const string Sold = "sold";
+
+    public static readonly IReadOnlySet<string> Allowed = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+    {
+        Approved,
+        SentToCraftsman,
+        InternalSettingQc,
+        DiamondSorting,
+        StoneSetting,
+        Plating,
+        FinalPieceQc,
+        CompletePiece,
+        ReadyForSale,
+        Sold,
+    };
+
+    public static string NormalizeOrDefault(string? value, string fallback = Approved)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return fallback;
+        }
+
+        var normalized = value.Trim().ToLowerInvariant();
+        return Allowed.Contains(normalized) ? normalized : fallback;
+    }
+}
+
+public static class ManufacturingPieceTypes
+{
+    public static readonly IReadOnlySet<string> Allowed = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+    {
+        "earrings",
+        "bracelet",
+        "choker",
+        "necklace",
+        "brooch",
+        "ring",
+        "pendant",
+        "other",
+    };
+
+    public static string? NormalizeOrNull(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return null;
+        }
+
+        var normalized = value.Trim().ToLowerInvariant();
+        return Allowed.Contains(normalized) ? normalized : null;
+    }
+}
+
+public sealed class CustomerResponse
+{
+    public Guid Id { get; init; }
+    public string Name { get; init; } = string.Empty;
+    public string? Nickname { get; init; }
+    public string? Email { get; init; }
+    public string? Phone { get; init; }
+    public string? Address { get; init; }
+    public string? Notes { get; init; }
+    public string? PhotoUrl { get; init; }
+    public DateTime? CustomerSince { get; init; }
+    public DateTime CreatedAtUtc { get; init; }
+    public DateTime UpdatedAtUtc { get; init; }
+    public decimal TotalSpent { get; init; }
+    public int PurchaseCount { get; init; }
+}
+
+public sealed class CustomerUpsertRequest
+{
+    public string? Name { get; init; }
+    public string? Nickname { get; init; }
+    public string? Email { get; init; }
+    public string? Phone { get; init; }
+    public string? Address { get; init; }
+    public string? Notes { get; init; }
+    public string? PhotoUrl { get; init; }
+    public DateTime? CustomerSince { get; init; }
+}
+
+public sealed class CustomerNoteRequest
+{
+    public string? Note { get; init; }
+}
+
+public sealed class CustomerActivityResponse
+{
+    public int Id { get; init; }
+    public int ProjectId { get; init; }
+    public string ManufacturingCode { get; init; } = string.Empty;
+    public string PieceName { get; init; } = string.Empty;
+    public string Status { get; init; } = string.Empty;
+    public DateTime ActivityAtUtc { get; init; }
+    public string? CraftsmanName { get; init; }
+    public string? Notes { get; init; }
+}
+
+public sealed class ManufacturingGemstoneResponse
+{
+    public int Id { get; init; }
+    public int? InventoryItemId { get; init; }
+    public string? GemstoneCode { get; init; }
+    public string? GemstoneType { get; init; }
+    public decimal PiecesUsed { get; init; }
+    public decimal WeightUsedCt { get; init; }
+    public decimal LineCost { get; init; }
+    public string? Notes { get; init; }
+}
+
+public sealed class ManufacturingActivityLogResponse
+{
+    public int Id { get; init; }
+    public string Status { get; init; } = string.Empty;
+    public DateTime ActivityAtUtc { get; init; }
+    public string? CraftsmanName { get; init; }
+    public string? Notes { get; init; }
+}
+
+public sealed class ManufacturingProjectSummaryResponse
+{
+    public int Id { get; init; }
+    public string ManufacturingCode { get; init; } = string.Empty;
+    public string PieceName { get; init; } = string.Empty;
+    public string? PieceType { get; init; }
+    public DateTime? DesignDate { get; init; }
+    public string? DesignerName { get; init; }
+    public string Status { get; init; } = ManufacturingStatuses.Approved;
+    public string? CraftsmanName { get; init; }
+    public IReadOnlyList<string> MetalPlating { get; init; } = [];
+    public decimal SettingCost { get; init; }
+    public decimal DiamondCost { get; init; }
+    public decimal GemstoneCost { get; init; }
+    public decimal TotalCost { get; init; }
+    public decimal SellingPrice { get; init; }
+    public DateTime? CompletionDate { get; init; }
+    public Guid? CustomerId { get; init; }
+    public string? CustomerName { get; init; }
+    public DateTime? SoldAt { get; init; }
+    public DateTime CreatedAtUtc { get; init; }
+    public DateTime UpdatedAtUtc { get; init; }
+    public int GemstoneCount { get; init; }
+}
+
+public sealed class ManufacturingProjectDetailResponse
+{
+    public int Id { get; init; }
+    public string ManufacturingCode { get; init; } = string.Empty;
+    public string PieceName { get; init; } = string.Empty;
+    public string? PieceType { get; init; }
+    public DateTime? DesignDate { get; init; }
+    public string? DesignerName { get; init; }
+    public string Status { get; init; } = ManufacturingStatuses.Approved;
+    public string? CraftsmanName { get; init; }
+    public IReadOnlyList<string> MetalPlating { get; init; } = [];
+    public string? MetalPlatingNotes { get; init; }
+    public decimal SettingCost { get; init; }
+    public decimal DiamondCost { get; init; }
+    public decimal GemstoneCost { get; init; }
+    public decimal TotalCost { get; init; }
+    public decimal SellingPrice { get; init; }
+    public DateTime? CompletionDate { get; init; }
+    public string? UsageNotes { get; init; }
+    public IReadOnlyList<string> Photos { get; init; } = [];
+    public Guid? CustomerId { get; init; }
+    public string? CustomerName { get; init; }
+    public DateTime? SoldAt { get; init; }
+    public DateTime CreatedAtUtc { get; init; }
+    public DateTime UpdatedAtUtc { get; init; }
+    public IReadOnlyList<ManufacturingGemstoneResponse> Gemstones { get; init; } = [];
+    public IReadOnlyList<ManufacturingActivityLogResponse> ActivityLog { get; init; } = [];
+}
+
+public sealed class ManufacturingGemstoneUpsertRequest
+{
+    public int? InventoryItemId { get; init; }
+    public string? GemstoneCode { get; init; }
+    public string? GemstoneType { get; init; }
+    public decimal? PiecesUsed { get; init; }
+    public decimal? WeightUsedCt { get; init; }
+    public decimal? LineCost { get; init; }
+    public string? Notes { get; init; }
+}
+
+public sealed class ManufacturingProjectUpsertRequest
+{
+    public string? ManufacturingCode { get; init; }
+    public string? PieceName { get; init; }
+    public string? PieceType { get; init; }
+    public DateTime? DesignDate { get; init; }
+    public string? DesignerName { get; init; }
+    public string? Status { get; init; }
+    public string? CraftsmanName { get; init; }
+    public IReadOnlyList<string>? MetalPlating { get; init; }
+    public string? MetalPlatingNotes { get; init; }
+    public decimal? SettingCost { get; init; }
+    public decimal? DiamondCost { get; init; }
+    public decimal? GemstoneCost { get; init; }
+    public decimal? TotalCost { get; init; }
+    public decimal? SellingPrice { get; init; }
+    public DateTime? CompletionDate { get; init; }
+    public string? UsageNotes { get; init; }
+    public IReadOnlyList<string>? Photos { get; init; }
+    public Guid? CustomerId { get; init; }
+    public DateTime? SoldAt { get; init; }
+    public IReadOnlyList<ManufacturingGemstoneUpsertRequest>? Gemstones { get; init; }
+    public string? ActivityNote { get; init; }
+}
+
+public sealed class AnalyticsCurrentMonthResponse
+{
+    public decimal Revenue { get; init; }
+    public int Transactions { get; init; }
+    public DateTime StartDateUtc { get; init; }
+}
+
+public sealed class AnalyticsTotalsResponse
+{
+    public decimal Revenue { get; init; }
+    public int Orders { get; init; }
+    public decimal AvgOrderValue { get; init; }
+    public int Customers { get; init; }
+    public int CustomersWithPurchases { get; init; }
+}
+
+public sealed class AnalyticsMonthlyRevenuePoint
+{
+    public string Month { get; init; } = string.Empty;
+    public decimal Revenue { get; init; }
+    public int Customers { get; init; }
+    public int Orders { get; init; }
+}
+
+public sealed class AnalyticsTopCustomerPoint
+{
+    public Guid CustomerId { get; init; }
+    public string CustomerName { get; init; } = string.Empty;
+    public decimal TotalSpent { get; init; }
+    public int Purchases { get; init; }
+    public DateTime LastPurchaseUtc { get; init; }
+}
+
+public sealed class AnalyticsOverviewResponse
+{
+    public AnalyticsCurrentMonthResponse CurrentMonth { get; init; } = new();
+    public AnalyticsTotalsResponse Totals { get; init; } = new();
+    public IReadOnlyList<AnalyticsMonthlyRevenuePoint> MonthlyRevenue { get; init; } = [];
+    public IReadOnlyList<AnalyticsTopCustomerPoint> TopCustomers { get; init; } = [];
+}

--- a/backend/Program.cs
+++ b/backend/Program.cs
@@ -52,11 +52,13 @@ if (!IsMissingOrPlaceholder(sqlConnection))
 {
     builder.Services.AddSingleton<ISqlDataService, SqlDataService>();
     builder.Services.AddSingleton<IGemInventorySqlService, GemInventorySqlService>();
+    builder.Services.AddSingleton<ICustomerManufacturingSqlService, CustomerManufacturingSqlService>();
 }
 else
 {
     builder.Services.AddSingleton<ISqlDataService, NoopSqlDataService>();
     builder.Services.AddSingleton<IGemInventorySqlService, NoopGemInventorySqlService>();
+    builder.Services.AddSingleton<ICustomerManufacturingSqlService, NoopCustomerManufacturingSqlService>();
 }
 
 builder.UseMiddleware<CorsMiddleware>();

--- a/backend/Services/CustomerManufacturingSqlService.cs
+++ b/backend/Services/CustomerManufacturingSqlService.cs
@@ -1,0 +1,1396 @@
+using System.Globalization;
+using System.Text.Json;
+using backend.Models;
+using Microsoft.Data.SqlClient;
+using Microsoft.Extensions.Configuration;
+
+namespace backend.Services;
+
+public interface ICustomerManufacturingSqlService
+{
+    Task<PagedResponse<CustomerResponse>> GetCustomersAsync(string? search, int limit, int offset, CancellationToken cancellationToken = default);
+    Task<CustomerResponse?> GetCustomerByIdAsync(Guid customerId, CancellationToken cancellationToken = default);
+    Task<CustomerResponse> CreateCustomerAsync(CustomerUpsertRequest request, CancellationToken cancellationToken = default);
+    Task<CustomerResponse?> UpdateCustomerAsync(Guid customerId, CustomerUpsertRequest request, CancellationToken cancellationToken = default);
+    Task<bool> DeleteCustomerAsync(Guid customerId, CancellationToken cancellationToken = default);
+    Task<bool> AppendCustomerNoteAsync(Guid customerId, string note, CancellationToken cancellationToken = default);
+    Task<IReadOnlyList<CustomerActivityResponse>> GetCustomerActivityAsync(Guid customerId, int limit, CancellationToken cancellationToken = default);
+
+    Task<PagedResponse<ManufacturingProjectSummaryResponse>> GetManufacturingProjectsAsync(
+        string? search,
+        string? status,
+        Guid? customerId,
+        int limit,
+        int offset,
+        CancellationToken cancellationToken = default);
+    Task<ManufacturingProjectDetailResponse?> GetManufacturingProjectByIdAsync(int projectId, CancellationToken cancellationToken = default);
+    Task<ManufacturingProjectDetailResponse> CreateManufacturingProjectAsync(
+        ManufacturingProjectUpsertRequest request,
+        CancellationToken cancellationToken = default);
+    Task<ManufacturingProjectDetailResponse?> UpdateManufacturingProjectAsync(
+        int projectId,
+        ManufacturingProjectUpsertRequest request,
+        CancellationToken cancellationToken = default);
+    Task<bool> DeleteManufacturingProjectAsync(int projectId, CancellationToken cancellationToken = default);
+
+    Task<AnalyticsOverviewResponse> GetAnalyticsAsync(CancellationToken cancellationToken = default);
+}
+
+public sealed class CustomerManufacturingSqlService : ICustomerManufacturingSqlService
+{
+    private readonly string _connectionString;
+
+    public CustomerManufacturingSqlService(IConfiguration configuration)
+    {
+        _connectionString = configuration["SqlConnection"]
+            ?? throw new InvalidOperationException("Missing SqlConnection configuration value.");
+    }
+
+    public async Task<PagedResponse<CustomerResponse>> GetCustomersAsync(
+        string? search,
+        int limit,
+        int offset,
+        CancellationToken cancellationToken = default)
+    {
+        (limit, offset) = NormalizePaging(limit, offset);
+
+        var whereClause = BuildCustomerSearchWhereClause(search);
+        var countSql = $"SELECT COUNT(*) FROM dbo.customers c {whereClause};";
+        var listSql = $"""
+            SELECT
+                c.id,
+                c.name,
+                c.nickname,
+                c.email,
+                c.phone,
+                c.address,
+                c.notes,
+                c.photo_url,
+                c.customer_since,
+                c.created_at_utc,
+                c.updated_at_utc,
+                COALESCE(s.total_spent, 0) AS total_spent,
+                COALESCE(s.purchase_count, 0) AS purchase_count
+            FROM dbo.customers c
+            OUTER APPLY (
+                SELECT
+                    SUM(COALESCE(mp.selling_price, 0)) AS total_spent,
+                    COUNT(*) AS purchase_count
+                FROM dbo.manufacturing_projects mp
+                WHERE mp.customer_id = c.id
+                  AND mp.status = 'sold'
+            ) s
+            {whereClause}
+            ORDER BY c.created_at_utc DESC, c.name
+            OFFSET @Offset ROWS FETCH NEXT @Limit ROWS ONLY;
+            """;
+
+        await using var conn = new SqlConnection(_connectionString);
+        await conn.OpenAsync(cancellationToken);
+
+        int totalCount;
+        await using (var countCmd = new SqlCommand(countSql, conn))
+        {
+            ApplyCustomerSearchParams(countCmd, search);
+            totalCount = Convert.ToInt32(await countCmd.ExecuteScalarAsync(cancellationToken) ?? 0);
+        }
+
+        var items = new List<CustomerResponse>();
+        await using (var listCmd = new SqlCommand(listSql, conn))
+        {
+            ApplyCustomerSearchParams(listCmd, search);
+            listCmd.Parameters.AddWithValue("@Offset", offset);
+            listCmd.Parameters.AddWithValue("@Limit", limit);
+
+            await using var reader = await listCmd.ExecuteReaderAsync(cancellationToken);
+            while (await reader.ReadAsync(cancellationToken))
+            {
+                items.Add(MapCustomer(reader));
+            }
+        }
+
+        return new PagedResponse<CustomerResponse>(items, totalCount, limit, offset);
+    }
+
+    public async Task<CustomerResponse?> GetCustomerByIdAsync(Guid customerId, CancellationToken cancellationToken = default)
+    {
+        const string sql = """
+            SELECT
+                c.id,
+                c.name,
+                c.nickname,
+                c.email,
+                c.phone,
+                c.address,
+                c.notes,
+                c.photo_url,
+                c.customer_since,
+                c.created_at_utc,
+                c.updated_at_utc,
+                COALESCE(s.total_spent, 0) AS total_spent,
+                COALESCE(s.purchase_count, 0) AS purchase_count
+            FROM dbo.customers c
+            OUTER APPLY (
+                SELECT
+                    SUM(COALESCE(mp.selling_price, 0)) AS total_spent,
+                    COUNT(*) AS purchase_count
+                FROM dbo.manufacturing_projects mp
+                WHERE mp.customer_id = c.id
+                  AND mp.status = 'sold'
+            ) s
+            WHERE c.id = @CustomerId;
+            """;
+
+        await using var conn = new SqlConnection(_connectionString);
+        await conn.OpenAsync(cancellationToken);
+
+        await using var cmd = new SqlCommand(sql, conn);
+        cmd.Parameters.AddWithValue("@CustomerId", customerId);
+
+        await using var reader = await cmd.ExecuteReaderAsync(cancellationToken);
+        if (!await reader.ReadAsync(cancellationToken))
+        {
+            return null;
+        }
+
+        return MapCustomer(reader);
+    }
+
+    public async Task<CustomerResponse> CreateCustomerAsync(CustomerUpsertRequest request, CancellationToken cancellationToken = default)
+    {
+        var normalizedName = NormalizeRequired(request.Name, "Customer name is required.");
+
+        const string sql = """
+            INSERT INTO dbo.customers (
+                name,
+                nickname,
+                email,
+                phone,
+                address,
+                notes,
+                photo_url,
+                customer_since,
+                updated_at_utc
+            )
+            OUTPUT INSERTED.id
+            VALUES (
+                @Name,
+                @Nickname,
+                @Email,
+                @Phone,
+                @Address,
+                @Notes,
+                @PhotoUrl,
+                @CustomerSince,
+                SYSUTCDATETIME()
+            );
+            """;
+
+        await using var conn = new SqlConnection(_connectionString);
+        await conn.OpenAsync(cancellationToken);
+
+        Guid createdId;
+        await using (var cmd = new SqlCommand(sql, conn))
+        {
+            cmd.Parameters.AddWithValue("@Name", normalizedName);
+            cmd.Parameters.AddWithValue("@Nickname", DbNullIfEmpty(request.Nickname));
+            cmd.Parameters.AddWithValue("@Email", DbNullIfEmpty(request.Email));
+            cmd.Parameters.AddWithValue("@Phone", DbNullIfEmpty(request.Phone));
+            cmd.Parameters.AddWithValue("@Address", DbNullIfEmpty(request.Address));
+            cmd.Parameters.AddWithValue("@Notes", DbNullIfEmpty(request.Notes));
+            cmd.Parameters.AddWithValue("@PhotoUrl", DbNullIfEmpty(request.PhotoUrl));
+            cmd.Parameters.AddWithValue("@CustomerSince", DbValue(request.CustomerSince));
+            createdId = (Guid)(await cmd.ExecuteScalarAsync(cancellationToken) ?? Guid.Empty);
+        }
+
+        var created = await GetCustomerByIdAsync(createdId, cancellationToken);
+        if (created is null)
+        {
+            throw new InvalidOperationException("Customer was created but could not be read back.");
+        }
+
+        return created;
+    }
+
+    public async Task<CustomerResponse?> UpdateCustomerAsync(
+        Guid customerId,
+        CustomerUpsertRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        var existing = await GetCustomerByIdAsync(customerId, cancellationToken);
+        if (existing is null)
+        {
+            return null;
+        }
+
+        var normalizedName = string.IsNullOrWhiteSpace(request.Name)
+            ? existing.Name
+            : request.Name.Trim();
+        var customerSince = request.CustomerSince ?? existing.CustomerSince;
+
+        const string sql = """
+            UPDATE dbo.customers
+            SET
+                name = @Name,
+                nickname = @Nickname,
+                email = @Email,
+                phone = @Phone,
+                address = @Address,
+                notes = @Notes,
+                photo_url = @PhotoUrl,
+                customer_since = @CustomerSince,
+                updated_at_utc = SYSUTCDATETIME()
+            WHERE id = @CustomerId;
+            """;
+
+        await using var conn = new SqlConnection(_connectionString);
+        await conn.OpenAsync(cancellationToken);
+
+        await using (var cmd = new SqlCommand(sql, conn))
+        {
+            cmd.Parameters.AddWithValue("@CustomerId", customerId);
+            cmd.Parameters.AddWithValue("@Name", normalizedName);
+            cmd.Parameters.AddWithValue("@Nickname", request.Nickname is null ? DbNullIfEmpty(existing.Nickname) : DbNullIfEmpty(request.Nickname));
+            cmd.Parameters.AddWithValue("@Email", request.Email is null ? DbNullIfEmpty(existing.Email) : DbNullIfEmpty(request.Email));
+            cmd.Parameters.AddWithValue("@Phone", request.Phone is null ? DbNullIfEmpty(existing.Phone) : DbNullIfEmpty(request.Phone));
+            cmd.Parameters.AddWithValue("@Address", request.Address is null ? DbNullIfEmpty(existing.Address) : DbNullIfEmpty(request.Address));
+            cmd.Parameters.AddWithValue("@Notes", request.Notes is null ? DbNullIfEmpty(existing.Notes) : DbNullIfEmpty(request.Notes));
+            cmd.Parameters.AddWithValue("@PhotoUrl", request.PhotoUrl is null ? DbNullIfEmpty(existing.PhotoUrl) : DbNullIfEmpty(request.PhotoUrl));
+            cmd.Parameters.AddWithValue("@CustomerSince", DbValue(customerSince));
+            var rows = await cmd.ExecuteNonQueryAsync(cancellationToken);
+            if (rows <= 0)
+            {
+                return null;
+            }
+        }
+
+        return await GetCustomerByIdAsync(customerId, cancellationToken);
+    }
+
+    public async Task<bool> DeleteCustomerAsync(Guid customerId, CancellationToken cancellationToken = default)
+    {
+        const string sql = "DELETE FROM dbo.customers WHERE id = @CustomerId;";
+
+        await using var conn = new SqlConnection(_connectionString);
+        await conn.OpenAsync(cancellationToken);
+
+        await using var cmd = new SqlCommand(sql, conn);
+        cmd.Parameters.AddWithValue("@CustomerId", customerId);
+        var rows = await cmd.ExecuteNonQueryAsync(cancellationToken);
+        return rows > 0;
+    }
+
+    public async Task<bool> AppendCustomerNoteAsync(Guid customerId, string note, CancellationToken cancellationToken = default)
+    {
+        var normalizedNote = NormalizeRequired(note, "Customer note is required.");
+        var noteEntry = $"[{DateTime.UtcNow:O}] {normalizedNote}";
+
+        const string sql = """
+            UPDATE dbo.customers
+            SET
+                notes = CASE
+                    WHEN notes IS NULL OR LTRIM(RTRIM(notes)) = '' THEN @NoteEntry
+                    ELSE CONCAT(notes, CHAR(10), CHAR(10), @NoteEntry)
+                END,
+                updated_at_utc = SYSUTCDATETIME()
+            WHERE id = @CustomerId;
+            """;
+
+        await using var conn = new SqlConnection(_connectionString);
+        await conn.OpenAsync(cancellationToken);
+
+        await using var cmd = new SqlCommand(sql, conn);
+        cmd.Parameters.AddWithValue("@CustomerId", customerId);
+        cmd.Parameters.AddWithValue("@NoteEntry", noteEntry);
+        var rows = await cmd.ExecuteNonQueryAsync(cancellationToken);
+        return rows > 0;
+    }
+
+    public async Task<IReadOnlyList<CustomerActivityResponse>> GetCustomerActivityAsync(
+        Guid customerId,
+        int limit,
+        CancellationToken cancellationToken = default)
+    {
+        const string sql = """
+            SELECT TOP (@Limit)
+                l.id,
+                l.project_id,
+                p.manufacturing_code,
+                p.piece_name,
+                l.status,
+                l.activity_at_utc,
+                l.craftsman_name,
+                l.notes
+            FROM dbo.manufacturing_activity_log l
+            INNER JOIN dbo.manufacturing_projects p
+                ON p.id = l.project_id
+            WHERE p.customer_id = @CustomerId
+            ORDER BY l.activity_at_utc DESC, l.id DESC;
+            """;
+
+        await using var conn = new SqlConnection(_connectionString);
+        await conn.OpenAsync(cancellationToken);
+
+        var items = new List<CustomerActivityResponse>();
+        await using var cmd = new SqlCommand(sql, conn);
+        cmd.Parameters.AddWithValue("@CustomerId", customerId);
+        cmd.Parameters.AddWithValue("@Limit", Math.Clamp(limit, 1, 200));
+
+        await using var reader = await cmd.ExecuteReaderAsync(cancellationToken);
+        while (await reader.ReadAsync(cancellationToken))
+        {
+            items.Add(new CustomerActivityResponse
+            {
+                Id = GetInt32(reader, "id"),
+                ProjectId = GetInt32(reader, "project_id"),
+                ManufacturingCode = GetString(reader, "manufacturing_code"),
+                PieceName = GetString(reader, "piece_name"),
+                Status = GetString(reader, "status"),
+                ActivityAtUtc = GetDateTime(reader, "activity_at_utc"),
+                CraftsmanName = GetNullableString(reader, "craftsman_name"),
+                Notes = GetNullableString(reader, "notes"),
+            });
+        }
+
+        return items;
+    }
+
+    public async Task<PagedResponse<ManufacturingProjectSummaryResponse>> GetManufacturingProjectsAsync(
+        string? search,
+        string? status,
+        Guid? customerId,
+        int limit,
+        int offset,
+        CancellationToken cancellationToken = default)
+    {
+        (limit, offset) = NormalizePaging(limit, offset);
+        var whereClause = BuildManufacturingWhereClause(search, status, customerId);
+
+        var countSql = $"SELECT COUNT(*) FROM dbo.manufacturing_projects mp LEFT JOIN dbo.customers c ON c.id = mp.customer_id {whereClause};";
+        var listSql = $"""
+            SELECT
+                mp.id,
+                mp.manufacturing_code,
+                mp.piece_name,
+                mp.piece_type,
+                mp.design_date,
+                mp.designer_name,
+                mp.status,
+                mp.craftsman_name,
+                mp.metal_plating_json,
+                mp.setting_cost,
+                mp.diamond_cost,
+                mp.gemstone_cost,
+                mp.total_cost,
+                mp.selling_price,
+                mp.completion_date,
+                mp.customer_id,
+                mp.sold_at,
+                mp.created_at_utc,
+                mp.updated_at_utc,
+                c.name AS customer_name,
+                (
+                    SELECT COUNT(*)
+                    FROM dbo.manufacturing_project_gemstones mg
+                    WHERE mg.project_id = mp.id
+                ) AS gemstone_count
+            FROM dbo.manufacturing_projects mp
+            LEFT JOIN dbo.customers c
+                ON c.id = mp.customer_id
+            {whereClause}
+            ORDER BY mp.updated_at_utc DESC, mp.id DESC
+            OFFSET @Offset ROWS FETCH NEXT @Limit ROWS ONLY;
+            """;
+
+        await using var conn = new SqlConnection(_connectionString);
+        await conn.OpenAsync(cancellationToken);
+
+        int totalCount;
+        await using (var countCmd = new SqlCommand(countSql, conn))
+        {
+            ApplyManufacturingParams(countCmd, search, status, customerId);
+            totalCount = Convert.ToInt32(await countCmd.ExecuteScalarAsync(cancellationToken) ?? 0);
+        }
+
+        var items = new List<ManufacturingProjectSummaryResponse>();
+        await using (var listCmd = new SqlCommand(listSql, conn))
+        {
+            ApplyManufacturingParams(listCmd, search, status, customerId);
+            listCmd.Parameters.AddWithValue("@Offset", offset);
+            listCmd.Parameters.AddWithValue("@Limit", limit);
+
+            await using var reader = await listCmd.ExecuteReaderAsync(cancellationToken);
+            while (await reader.ReadAsync(cancellationToken))
+            {
+                items.Add(MapManufacturingSummary(reader));
+            }
+        }
+
+        return new PagedResponse<ManufacturingProjectSummaryResponse>(items, totalCount, limit, offset);
+    }
+
+    public async Task<ManufacturingProjectDetailResponse?> GetManufacturingProjectByIdAsync(
+        int projectId,
+        CancellationToken cancellationToken = default)
+    {
+        const string projectSql = """
+            SELECT
+                mp.id,
+                mp.manufacturing_code,
+                mp.piece_name,
+                mp.piece_type,
+                mp.design_date,
+                mp.designer_name,
+                mp.status,
+                mp.craftsman_name,
+                mp.metal_plating_json,
+                mp.metal_plating_notes,
+                mp.setting_cost,
+                mp.diamond_cost,
+                mp.gemstone_cost,
+                mp.total_cost,
+                mp.selling_price,
+                mp.completion_date,
+                mp.usage_notes,
+                mp.photos_json,
+                mp.customer_id,
+                mp.sold_at,
+                mp.created_at_utc,
+                mp.updated_at_utc,
+                c.name AS customer_name
+            FROM dbo.manufacturing_projects mp
+            LEFT JOIN dbo.customers c
+                ON c.id = mp.customer_id
+            WHERE mp.id = @ProjectId;
+            """;
+
+        const string gemstonesSql = """
+            SELECT
+                mg.id,
+                mg.inventory_item_id,
+                mg.gemstone_code,
+                COALESCE(mg.gemstone_type, gi.gemstone_type) AS gemstone_type,
+                mg.pieces_used,
+                mg.weight_used_ct,
+                mg.line_cost,
+                mg.notes
+            FROM dbo.manufacturing_project_gemstones mg
+            LEFT JOIN dbo.gem_inventory_items gi
+                ON gi.id = mg.inventory_item_id
+            WHERE mg.project_id = @ProjectId
+            ORDER BY mg.id;
+            """;
+
+        const string activitySql = """
+            SELECT
+                id,
+                status,
+                activity_at_utc,
+                craftsman_name,
+                notes
+            FROM dbo.manufacturing_activity_log
+            WHERE project_id = @ProjectId
+            ORDER BY activity_at_utc DESC, id DESC;
+            """;
+
+        await using var conn = new SqlConnection(_connectionString);
+        await conn.OpenAsync(cancellationToken);
+
+        ManufacturingProjectDetailResponse? detail;
+        await using (var projectCmd = new SqlCommand(projectSql, conn))
+        {
+            projectCmd.Parameters.AddWithValue("@ProjectId", projectId);
+            await using var reader = await projectCmd.ExecuteReaderAsync(cancellationToken);
+            if (!await reader.ReadAsync(cancellationToken))
+            {
+                return null;
+            }
+
+            detail = MapManufacturingDetail(reader);
+        }
+
+        var gemstones = new List<ManufacturingGemstoneResponse>();
+        await using (var gemstonesCmd = new SqlCommand(gemstonesSql, conn))
+        {
+            gemstonesCmd.Parameters.AddWithValue("@ProjectId", projectId);
+            await using var reader = await gemstonesCmd.ExecuteReaderAsync(cancellationToken);
+            while (await reader.ReadAsync(cancellationToken))
+            {
+                gemstones.Add(new ManufacturingGemstoneResponse
+                {
+                    Id = GetInt32(reader, "id"),
+                    InventoryItemId = GetNullableInt32(reader, "inventory_item_id"),
+                    GemstoneCode = GetNullableString(reader, "gemstone_code"),
+                    GemstoneType = GetNullableString(reader, "gemstone_type"),
+                    PiecesUsed = GetDecimal(reader, "pieces_used"),
+                    WeightUsedCt = GetDecimal(reader, "weight_used_ct"),
+                    LineCost = GetDecimal(reader, "line_cost"),
+                    Notes = GetNullableString(reader, "notes"),
+                });
+            }
+        }
+
+        var activity = new List<ManufacturingActivityLogResponse>();
+        await using (var activityCmd = new SqlCommand(activitySql, conn))
+        {
+            activityCmd.Parameters.AddWithValue("@ProjectId", projectId);
+            await using var reader = await activityCmd.ExecuteReaderAsync(cancellationToken);
+            while (await reader.ReadAsync(cancellationToken))
+            {
+                activity.Add(new ManufacturingActivityLogResponse
+                {
+                    Id = GetInt32(reader, "id"),
+                    Status = GetString(reader, "status"),
+                    ActivityAtUtc = GetDateTime(reader, "activity_at_utc"),
+                    CraftsmanName = GetNullableString(reader, "craftsman_name"),
+                    Notes = GetNullableString(reader, "notes"),
+                });
+            }
+        }
+
+        return new ManufacturingProjectDetailResponse
+        {
+            Id = detail.Id,
+            ManufacturingCode = detail.ManufacturingCode,
+            PieceName = detail.PieceName,
+            PieceType = detail.PieceType,
+            DesignDate = detail.DesignDate,
+            DesignerName = detail.DesignerName,
+            Status = detail.Status,
+            CraftsmanName = detail.CraftsmanName,
+            MetalPlating = detail.MetalPlating,
+            MetalPlatingNotes = detail.MetalPlatingNotes,
+            SettingCost = detail.SettingCost,
+            DiamondCost = detail.DiamondCost,
+            GemstoneCost = detail.GemstoneCost,
+            TotalCost = detail.TotalCost,
+            SellingPrice = detail.SellingPrice,
+            CompletionDate = detail.CompletionDate,
+            UsageNotes = detail.UsageNotes,
+            Photos = detail.Photos,
+            CustomerId = detail.CustomerId,
+            CustomerName = detail.CustomerName,
+            SoldAt = detail.SoldAt,
+            CreatedAtUtc = detail.CreatedAtUtc,
+            UpdatedAtUtc = detail.UpdatedAtUtc,
+            Gemstones = gemstones,
+            ActivityLog = activity,
+        };
+    }
+
+    public async Task<ManufacturingProjectDetailResponse> CreateManufacturingProjectAsync(
+        ManufacturingProjectUpsertRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        var manufacturingCode = NormalizeRequired(request.ManufacturingCode, "Manufacturing code is required.");
+        var pieceName = NormalizeRequired(request.PieceName, "Piece name is required.");
+        var status = ManufacturingStatuses.NormalizeOrDefault(request.Status, ManufacturingStatuses.Approved);
+        var pieceType = ManufacturingPieceTypes.NormalizeOrNull(request.PieceType);
+
+        const string insertSql = """
+            INSERT INTO dbo.manufacturing_projects (
+                manufacturing_code,
+                piece_name,
+                piece_type,
+                design_date,
+                designer_name,
+                status,
+                craftsman_name,
+                metal_plating_json,
+                metal_plating_notes,
+                setting_cost,
+                diamond_cost,
+                gemstone_cost,
+                total_cost,
+                selling_price,
+                completion_date,
+                usage_notes,
+                photos_json,
+                customer_id,
+                sold_at,
+                updated_at_utc
+            )
+            OUTPUT INSERTED.id
+            VALUES (
+                @ManufacturingCode,
+                @PieceName,
+                @PieceType,
+                @DesignDate,
+                @DesignerName,
+                @Status,
+                @CraftsmanName,
+                @MetalPlatingJson,
+                @MetalPlatingNotes,
+                @SettingCost,
+                @DiamondCost,
+                @GemstoneCost,
+                @TotalCost,
+                @SellingPrice,
+                @CompletionDate,
+                @UsageNotes,
+                @PhotosJson,
+                @CustomerId,
+                @SoldAt,
+                SYSUTCDATETIME()
+            );
+            """;
+
+        await using var conn = new SqlConnection(_connectionString);
+        await conn.OpenAsync(cancellationToken);
+
+        await using var tx = (SqlTransaction)await conn.BeginTransactionAsync(cancellationToken);
+
+        try
+        {
+            int createdId;
+            await using (var insertCmd = new SqlCommand(insertSql, conn, tx))
+            {
+                insertCmd.Parameters.AddWithValue("@ManufacturingCode", manufacturingCode);
+                insertCmd.Parameters.AddWithValue("@PieceName", pieceName);
+                insertCmd.Parameters.AddWithValue("@PieceType", DbNullIfEmpty(pieceType));
+                insertCmd.Parameters.AddWithValue("@DesignDate", DbValue(request.DesignDate));
+                insertCmd.Parameters.AddWithValue("@DesignerName", DbNullIfEmpty(request.DesignerName));
+                insertCmd.Parameters.AddWithValue("@Status", status);
+                insertCmd.Parameters.AddWithValue("@CraftsmanName", DbNullIfEmpty(request.CraftsmanName));
+                insertCmd.Parameters.AddWithValue("@MetalPlatingJson", SerializeJsonArray(request.MetalPlating));
+                insertCmd.Parameters.AddWithValue("@MetalPlatingNotes", DbNullIfEmpty(request.MetalPlatingNotes));
+                insertCmd.Parameters.AddWithValue("@SettingCost", request.SettingCost ?? 0m);
+                insertCmd.Parameters.AddWithValue("@DiamondCost", request.DiamondCost ?? 0m);
+                insertCmd.Parameters.AddWithValue("@GemstoneCost", request.GemstoneCost ?? 0m);
+                insertCmd.Parameters.AddWithValue("@TotalCost", request.TotalCost ?? 0m);
+                insertCmd.Parameters.AddWithValue("@SellingPrice", request.SellingPrice ?? 0m);
+                insertCmd.Parameters.AddWithValue("@CompletionDate", DbValue(request.CompletionDate));
+                insertCmd.Parameters.AddWithValue("@UsageNotes", DbNullIfEmpty(request.UsageNotes));
+                insertCmd.Parameters.AddWithValue("@PhotosJson", SerializeJsonArray(request.Photos));
+                insertCmd.Parameters.AddWithValue("@CustomerId", DbValue(request.CustomerId));
+                insertCmd.Parameters.AddWithValue("@SoldAt", DbValue(request.SoldAt));
+
+                createdId = Convert.ToInt32(await insertCmd.ExecuteScalarAsync(cancellationToken) ?? 0);
+            }
+
+            await ReplaceProjectGemstonesAsync(conn, tx, createdId, request.Gemstones ?? [], cancellationToken);
+            await InsertActivityLogAsync(
+                conn,
+                tx,
+                createdId,
+                status,
+                request.CraftsmanName,
+                request.ActivityNote ?? $"Project created with status: {status}",
+                cancellationToken);
+
+            await tx.CommitAsync(cancellationToken);
+
+            var created = await GetManufacturingProjectByIdAsync(createdId, cancellationToken);
+            if (created is null)
+            {
+                throw new InvalidOperationException("Manufacturing project was created but could not be read back.");
+            }
+
+            return created;
+        }
+        catch
+        {
+            await tx.RollbackAsync(cancellationToken);
+            throw;
+        }
+    }
+
+    public async Task<ManufacturingProjectDetailResponse?> UpdateManufacturingProjectAsync(
+        int projectId,
+        ManufacturingProjectUpsertRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        var existing = await GetManufacturingProjectByIdAsync(projectId, cancellationToken);
+        if (existing is null)
+        {
+            return null;
+        }
+
+        var manufacturingCode = string.IsNullOrWhiteSpace(request.ManufacturingCode)
+            ? existing.ManufacturingCode
+            : request.ManufacturingCode.Trim();
+        var pieceName = string.IsNullOrWhiteSpace(request.PieceName)
+            ? existing.PieceName
+            : request.PieceName.Trim();
+        var pieceType = request.PieceType is null
+            ? existing.PieceType
+            : ManufacturingPieceTypes.NormalizeOrNull(request.PieceType);
+        var status = request.Status is null
+            ? existing.Status
+            : ManufacturingStatuses.NormalizeOrDefault(request.Status, existing.Status);
+
+        var soldAt = status == ManufacturingStatuses.Sold
+            ? request.SoldAt ?? existing.SoldAt ?? DateTime.UtcNow
+            : (request.Status is null ? existing.SoldAt : null);
+        var designDate = request.DesignDate ?? existing.DesignDate;
+        var completionDate = request.CompletionDate ?? existing.CompletionDate;
+
+        var customerId = request.CustomerId ?? existing.CustomerId;
+        if (status != ManufacturingStatuses.Sold && request.Status is not null)
+        {
+            customerId = request.CustomerId;
+        }
+
+        const string updateSql = """
+            UPDATE dbo.manufacturing_projects
+            SET
+                manufacturing_code = @ManufacturingCode,
+                piece_name = @PieceName,
+                piece_type = @PieceType,
+                design_date = @DesignDate,
+                designer_name = @DesignerName,
+                status = @Status,
+                craftsman_name = @CraftsmanName,
+                metal_plating_json = @MetalPlatingJson,
+                metal_plating_notes = @MetalPlatingNotes,
+                setting_cost = @SettingCost,
+                diamond_cost = @DiamondCost,
+                gemstone_cost = @GemstoneCost,
+                total_cost = @TotalCost,
+                selling_price = @SellingPrice,
+                completion_date = @CompletionDate,
+                usage_notes = @UsageNotes,
+                photos_json = @PhotosJson,
+                customer_id = @CustomerId,
+                sold_at = @SoldAt,
+                updated_at_utc = SYSUTCDATETIME()
+            WHERE id = @ProjectId;
+            """;
+
+        await using var conn = new SqlConnection(_connectionString);
+        await conn.OpenAsync(cancellationToken);
+
+        await using var tx = (SqlTransaction)await conn.BeginTransactionAsync(cancellationToken);
+
+        try
+        {
+            await using (var updateCmd = new SqlCommand(updateSql, conn, tx))
+            {
+                updateCmd.Parameters.AddWithValue("@ProjectId", projectId);
+                updateCmd.Parameters.AddWithValue("@ManufacturingCode", manufacturingCode);
+                updateCmd.Parameters.AddWithValue("@PieceName", pieceName);
+                updateCmd.Parameters.AddWithValue("@PieceType", DbNullIfEmpty(pieceType));
+                updateCmd.Parameters.AddWithValue("@DesignDate", DbValue(designDate));
+                updateCmd.Parameters.AddWithValue("@DesignerName", request.DesignerName is null ? DbNullIfEmpty(existing.DesignerName) : DbNullIfEmpty(request.DesignerName));
+                updateCmd.Parameters.AddWithValue("@Status", status);
+                updateCmd.Parameters.AddWithValue("@CraftsmanName", request.CraftsmanName is null ? DbNullIfEmpty(existing.CraftsmanName) : DbNullIfEmpty(request.CraftsmanName));
+                updateCmd.Parameters.AddWithValue("@MetalPlatingJson", SerializeJsonArray(request.MetalPlating ?? existing.MetalPlating));
+                updateCmd.Parameters.AddWithValue("@MetalPlatingNotes", request.MetalPlatingNotes is null ? DbNullIfEmpty(existing.MetalPlatingNotes) : DbNullIfEmpty(request.MetalPlatingNotes));
+                updateCmd.Parameters.AddWithValue("@SettingCost", request.SettingCost ?? existing.SettingCost);
+                updateCmd.Parameters.AddWithValue("@DiamondCost", request.DiamondCost ?? existing.DiamondCost);
+                updateCmd.Parameters.AddWithValue("@GemstoneCost", request.GemstoneCost ?? existing.GemstoneCost);
+                updateCmd.Parameters.AddWithValue("@TotalCost", request.TotalCost ?? existing.TotalCost);
+                updateCmd.Parameters.AddWithValue("@SellingPrice", request.SellingPrice ?? existing.SellingPrice);
+                updateCmd.Parameters.AddWithValue("@CompletionDate", DbValue(completionDate));
+                updateCmd.Parameters.AddWithValue("@UsageNotes", request.UsageNotes is null ? DbNullIfEmpty(existing.UsageNotes) : DbNullIfEmpty(request.UsageNotes));
+                updateCmd.Parameters.AddWithValue("@PhotosJson", SerializeJsonArray(request.Photos ?? existing.Photos));
+                updateCmd.Parameters.AddWithValue("@CustomerId", DbValue(customerId));
+                updateCmd.Parameters.AddWithValue("@SoldAt", DbValue(soldAt));
+
+                var rows = await updateCmd.ExecuteNonQueryAsync(cancellationToken);
+                if (rows <= 0)
+                {
+                    await tx.RollbackAsync(cancellationToken);
+                    return null;
+                }
+            }
+
+            if (request.Gemstones is not null)
+            {
+                await ReplaceProjectGemstonesAsync(conn, tx, projectId, request.Gemstones, cancellationToken);
+            }
+
+            var statusChanged = !string.Equals(existing.Status, status, StringComparison.OrdinalIgnoreCase);
+            if (statusChanged || !string.IsNullOrWhiteSpace(request.ActivityNote))
+            {
+                var activityNote = !string.IsNullOrWhiteSpace(request.ActivityNote)
+                    ? request.ActivityNote.Trim()
+                    : $"Status changed from {existing.Status} to {status}";
+
+                await InsertActivityLogAsync(
+                    conn,
+                    tx,
+                    projectId,
+                    status,
+                    request.CraftsmanName ?? existing.CraftsmanName,
+                    activityNote,
+                    cancellationToken);
+            }
+
+            await tx.CommitAsync(cancellationToken);
+            return await GetManufacturingProjectByIdAsync(projectId, cancellationToken);
+        }
+        catch
+        {
+            await tx.RollbackAsync(cancellationToken);
+            throw;
+        }
+    }
+
+    public async Task<bool> DeleteManufacturingProjectAsync(int projectId, CancellationToken cancellationToken = default)
+    {
+        const string sql = "DELETE FROM dbo.manufacturing_projects WHERE id = @ProjectId;";
+
+        await using var conn = new SqlConnection(_connectionString);
+        await conn.OpenAsync(cancellationToken);
+
+        await using var cmd = new SqlCommand(sql, conn);
+        cmd.Parameters.AddWithValue("@ProjectId", projectId);
+
+        var rows = await cmd.ExecuteNonQueryAsync(cancellationToken);
+        return rows > 0;
+    }
+
+    public async Task<AnalyticsOverviewResponse> GetAnalyticsAsync(CancellationToken cancellationToken = default)
+    {
+        const string soldSql = """
+            SELECT
+                mp.customer_id,
+                c.name AS customer_name,
+                mp.selling_price,
+                mp.total_cost,
+                mp.sold_at,
+                mp.created_at_utc
+            FROM dbo.manufacturing_projects mp
+            LEFT JOIN dbo.customers c
+                ON c.id = mp.customer_id
+            WHERE mp.status = 'sold';
+            """;
+
+        const string customersSql = "SELECT COUNT(*) FROM dbo.customers;";
+
+        await using var conn = new SqlConnection(_connectionString);
+        await conn.OpenAsync(cancellationToken);
+
+        var soldRows = new List<SoldProjectRow>();
+        await using (var soldCmd = new SqlCommand(soldSql, conn))
+        {
+            await using var reader = await soldCmd.ExecuteReaderAsync(cancellationToken);
+            while (await reader.ReadAsync(cancellationToken))
+            {
+                soldRows.Add(new SoldProjectRow
+                {
+                    CustomerId = GetNullableGuid(reader, "customer_id"),
+                    CustomerName = GetNullableString(reader, "customer_name"),
+                    SellingPrice = GetDecimal(reader, "selling_price"),
+                    TotalCost = GetDecimal(reader, "total_cost"),
+                    SoldAtUtc = GetNullableDateTime(reader, "sold_at"),
+                    CreatedAtUtc = GetDateTime(reader, "created_at_utc"),
+                });
+            }
+        }
+
+        int customerCount;
+        await using (var customersCmd = new SqlCommand(customersSql, conn))
+        {
+            customerCount = Convert.ToInt32(await customersCmd.ExecuteScalarAsync(cancellationToken) ?? 0);
+        }
+
+        var now = DateTime.UtcNow;
+        var currentMonthStart = new DateTime(now.Year, now.Month, 1, 0, 0, 0, DateTimeKind.Utc);
+        var currentMonthEnd = currentMonthStart.AddMonths(1);
+
+        var soldDateRows = soldRows
+            .Select(row => new
+            {
+                Row = row,
+                SoldDateUtc = row.SoldAtUtc ?? row.CreatedAtUtc,
+            })
+            .ToList();
+
+        var currentMonthSales = soldDateRows
+            .Where(item => item.SoldDateUtc >= currentMonthStart && item.SoldDateUtc < currentMonthEnd)
+            .ToList();
+
+        var totalRevenue = soldRows.Sum(row => row.SellingPrice);
+        var totalOrders = soldRows.Count;
+        var avgOrderValue = totalOrders > 0 ? totalRevenue / totalOrders : 0m;
+
+        var monthlyRevenue = new List<AnalyticsMonthlyRevenuePoint>();
+        for (var i = 5; i >= 0; i--)
+        {
+            var monthStart = currentMonthStart.AddMonths(-i);
+            var monthEnd = monthStart.AddMonths(1);
+
+            var monthSales = soldDateRows
+                .Where(item => item.SoldDateUtc >= monthStart && item.SoldDateUtc < monthEnd)
+                .ToList();
+
+            var monthCustomers = monthSales
+                .Select(item => item.Row.CustomerId)
+                .Where(value => value.HasValue)
+                .Select(value => value!.Value)
+                .Distinct()
+                .Count();
+
+            monthlyRevenue.Add(new AnalyticsMonthlyRevenuePoint
+            {
+                Month = monthStart.ToString("MMM", CultureInfo.InvariantCulture),
+                Revenue = monthSales.Sum(item => item.Row.SellingPrice),
+                Customers = monthCustomers,
+                Orders = monthSales.Count,
+            });
+        }
+
+        var topCustomers = soldRows
+            .Where(row => row.CustomerId.HasValue)
+            .GroupBy(row => row.CustomerId!.Value)
+            .Select(group =>
+            {
+                var latest = group
+                    .OrderByDescending(row => row.SoldAtUtc ?? row.CreatedAtUtc)
+                    .First();
+
+                return new AnalyticsTopCustomerPoint
+                {
+                    CustomerId = group.Key,
+                    CustomerName = string.IsNullOrWhiteSpace(latest.CustomerName) ? "Unknown Customer" : latest.CustomerName,
+                    TotalSpent = group.Sum(row => row.SellingPrice),
+                    Purchases = group.Count(),
+                    LastPurchaseUtc = group.Max(row => row.SoldAtUtc ?? row.CreatedAtUtc),
+                };
+            })
+            .OrderByDescending(item => item.TotalSpent)
+            .Take(5)
+            .ToList();
+
+        var customersWithPurchases = soldRows
+            .Select(row => row.CustomerId)
+            .Where(value => value.HasValue)
+            .Select(value => value!.Value)
+            .Distinct()
+            .Count();
+
+        return new AnalyticsOverviewResponse
+        {
+            CurrentMonth = new AnalyticsCurrentMonthResponse
+            {
+                Revenue = currentMonthSales.Sum(item => item.Row.SellingPrice),
+                Transactions = currentMonthSales.Count,
+                StartDateUtc = currentMonthStart,
+            },
+            Totals = new AnalyticsTotalsResponse
+            {
+                Revenue = totalRevenue,
+                Orders = totalOrders,
+                AvgOrderValue = avgOrderValue,
+                Customers = customerCount,
+                CustomersWithPurchases = customersWithPurchases,
+            },
+            MonthlyRevenue = monthlyRevenue,
+            TopCustomers = topCustomers,
+        };
+    }
+
+    private static string BuildCustomerSearchWhereClause(string? search)
+    {
+        if (string.IsNullOrWhiteSpace(search))
+        {
+            return string.Empty;
+        }
+
+        return "WHERE (c.name LIKE @Search OR c.nickname LIKE @Search OR c.email LIKE @Search OR c.phone LIKE @Search)";
+    }
+
+    private static void ApplyCustomerSearchParams(SqlCommand command, string? search)
+    {
+        if (!string.IsNullOrWhiteSpace(search))
+        {
+            command.Parameters.AddWithValue("@Search", $"%{search.Trim()}%");
+        }
+    }
+
+    private static string BuildManufacturingWhereClause(string? search, string? status, Guid? customerId)
+    {
+        var clauses = new List<string>();
+
+        if (!string.IsNullOrWhiteSpace(search))
+        {
+            clauses.Add("(mp.manufacturing_code LIKE @Search OR mp.piece_name LIKE @Search OR mp.designer_name LIKE @Search OR mp.craftsman_name LIKE @Search OR c.name LIKE @Search)");
+        }
+
+        if (!string.IsNullOrWhiteSpace(status) && !status.Equals("all", StringComparison.OrdinalIgnoreCase))
+        {
+            if (status.Equals("in_production", StringComparison.OrdinalIgnoreCase))
+            {
+                clauses.Add("mp.status NOT IN ('ready_for_sale', 'sold')");
+            }
+            else
+            {
+                clauses.Add("mp.status = @Status");
+            }
+        }
+
+        if (customerId.HasValue)
+        {
+            clauses.Add("mp.customer_id = @CustomerId");
+        }
+
+        return clauses.Count == 0 ? string.Empty : "WHERE " + string.Join(" AND ", clauses);
+    }
+
+    private static void ApplyManufacturingParams(SqlCommand command, string? search, string? status, Guid? customerId)
+    {
+        if (!string.IsNullOrWhiteSpace(search))
+        {
+            command.Parameters.AddWithValue("@Search", $"%{search.Trim()}%");
+        }
+
+        if (!string.IsNullOrWhiteSpace(status) &&
+            !status.Equals("all", StringComparison.OrdinalIgnoreCase) &&
+            !status.Equals("in_production", StringComparison.OrdinalIgnoreCase))
+        {
+            command.Parameters.AddWithValue("@Status", ManufacturingStatuses.NormalizeOrDefault(status));
+        }
+
+        if (customerId.HasValue)
+        {
+            command.Parameters.AddWithValue("@CustomerId", customerId.Value);
+        }
+    }
+
+    private static async Task ReplaceProjectGemstonesAsync(
+        SqlConnection conn,
+        SqlTransaction tx,
+        int projectId,
+        IReadOnlyList<ManufacturingGemstoneUpsertRequest> gemstones,
+        CancellationToken cancellationToken)
+    {
+        const string deleteSql = "DELETE FROM dbo.manufacturing_project_gemstones WHERE project_id = @ProjectId;";
+        await using (var deleteCmd = new SqlCommand(deleteSql, conn, tx))
+        {
+            deleteCmd.Parameters.AddWithValue("@ProjectId", projectId);
+            await deleteCmd.ExecuteNonQueryAsync(cancellationToken);
+        }
+
+        if (gemstones.Count == 0)
+        {
+            return;
+        }
+
+        const string insertSql = """
+            INSERT INTO dbo.manufacturing_project_gemstones (
+                project_id,
+                inventory_item_id,
+                gemstone_code,
+                gemstone_type,
+                pieces_used,
+                weight_used_ct,
+                line_cost,
+                notes
+            )
+            VALUES (
+                @ProjectId,
+                @InventoryItemId,
+                @GemstoneCode,
+                @GemstoneType,
+                @PiecesUsed,
+                @WeightUsedCt,
+                @LineCost,
+                @Notes
+            );
+            """;
+
+        foreach (var item in gemstones)
+        {
+            await using var insertCmd = new SqlCommand(insertSql, conn, tx);
+            insertCmd.Parameters.AddWithValue("@ProjectId", projectId);
+            insertCmd.Parameters.AddWithValue("@InventoryItemId", DbValue(item.InventoryItemId));
+            insertCmd.Parameters.AddWithValue("@GemstoneCode", DbNullIfEmpty(item.GemstoneCode));
+            insertCmd.Parameters.AddWithValue("@GemstoneType", DbNullIfEmpty(item.GemstoneType));
+            insertCmd.Parameters.AddWithValue("@PiecesUsed", item.PiecesUsed ?? 0m);
+            insertCmd.Parameters.AddWithValue("@WeightUsedCt", item.WeightUsedCt ?? 0m);
+            insertCmd.Parameters.AddWithValue("@LineCost", item.LineCost ?? 0m);
+            insertCmd.Parameters.AddWithValue("@Notes", DbNullIfEmpty(item.Notes));
+            await insertCmd.ExecuteNonQueryAsync(cancellationToken);
+        }
+    }
+
+    private static async Task InsertActivityLogAsync(
+        SqlConnection conn,
+        SqlTransaction tx,
+        int projectId,
+        string status,
+        string? craftsmanName,
+        string notes,
+        CancellationToken cancellationToken)
+    {
+        const string sql = """
+            INSERT INTO dbo.manufacturing_activity_log (
+                project_id,
+                status,
+                activity_at_utc,
+                craftsman_name,
+                notes
+            )
+            VALUES (
+                @ProjectId,
+                @Status,
+                SYSUTCDATETIME(),
+                @CraftsmanName,
+                @Notes
+            );
+            """;
+
+        await using var cmd = new SqlCommand(sql, conn, tx);
+        cmd.Parameters.AddWithValue("@ProjectId", projectId);
+        cmd.Parameters.AddWithValue("@Status", ManufacturingStatuses.NormalizeOrDefault(status));
+        cmd.Parameters.AddWithValue("@CraftsmanName", DbNullIfEmpty(craftsmanName));
+        cmd.Parameters.AddWithValue("@Notes", DbNullIfEmpty(notes));
+
+        await cmd.ExecuteNonQueryAsync(cancellationToken);
+    }
+
+    private static CustomerResponse MapCustomer(SqlDataReader reader)
+    {
+        return new CustomerResponse
+        {
+            Id = GetGuid(reader, "id"),
+            Name = GetString(reader, "name"),
+            Nickname = GetNullableString(reader, "nickname"),
+            Email = GetNullableString(reader, "email"),
+            Phone = GetNullableString(reader, "phone"),
+            Address = GetNullableString(reader, "address"),
+            Notes = GetNullableString(reader, "notes"),
+            PhotoUrl = GetNullableString(reader, "photo_url"),
+            CustomerSince = GetNullableDateTime(reader, "customer_since"),
+            CreatedAtUtc = GetDateTime(reader, "created_at_utc"),
+            UpdatedAtUtc = GetDateTime(reader, "updated_at_utc"),
+            TotalSpent = GetDecimal(reader, "total_spent"),
+            PurchaseCount = GetInt32(reader, "purchase_count"),
+        };
+    }
+
+    private static ManufacturingProjectSummaryResponse MapManufacturingSummary(SqlDataReader reader)
+    {
+        return new ManufacturingProjectSummaryResponse
+        {
+            Id = GetInt32(reader, "id"),
+            ManufacturingCode = GetString(reader, "manufacturing_code"),
+            PieceName = GetString(reader, "piece_name"),
+            PieceType = GetNullableString(reader, "piece_type"),
+            DesignDate = GetNullableDateTime(reader, "design_date"),
+            DesignerName = GetNullableString(reader, "designer_name"),
+            Status = GetString(reader, "status"),
+            CraftsmanName = GetNullableString(reader, "craftsman_name"),
+            MetalPlating = DeserializeJsonArray(GetNullableString(reader, "metal_plating_json")),
+            SettingCost = GetDecimal(reader, "setting_cost"),
+            DiamondCost = GetDecimal(reader, "diamond_cost"),
+            GemstoneCost = GetDecimal(reader, "gemstone_cost"),
+            TotalCost = GetDecimal(reader, "total_cost"),
+            SellingPrice = GetDecimal(reader, "selling_price"),
+            CompletionDate = GetNullableDateTime(reader, "completion_date"),
+            CustomerId = GetNullableGuid(reader, "customer_id"),
+            CustomerName = GetNullableString(reader, "customer_name"),
+            SoldAt = GetNullableDateTime(reader, "sold_at"),
+            CreatedAtUtc = GetDateTime(reader, "created_at_utc"),
+            UpdatedAtUtc = GetDateTime(reader, "updated_at_utc"),
+            GemstoneCount = GetInt32(reader, "gemstone_count"),
+        };
+    }
+
+    private static ManufacturingProjectDetailResponse MapManufacturingDetail(SqlDataReader reader)
+    {
+        return new ManufacturingProjectDetailResponse
+        {
+            Id = GetInt32(reader, "id"),
+            ManufacturingCode = GetString(reader, "manufacturing_code"),
+            PieceName = GetString(reader, "piece_name"),
+            PieceType = GetNullableString(reader, "piece_type"),
+            DesignDate = GetNullableDateTime(reader, "design_date"),
+            DesignerName = GetNullableString(reader, "designer_name"),
+            Status = GetString(reader, "status"),
+            CraftsmanName = GetNullableString(reader, "craftsman_name"),
+            MetalPlating = DeserializeJsonArray(GetNullableString(reader, "metal_plating_json")),
+            MetalPlatingNotes = GetNullableString(reader, "metal_plating_notes"),
+            SettingCost = GetDecimal(reader, "setting_cost"),
+            DiamondCost = GetDecimal(reader, "diamond_cost"),
+            GemstoneCost = GetDecimal(reader, "gemstone_cost"),
+            TotalCost = GetDecimal(reader, "total_cost"),
+            SellingPrice = GetDecimal(reader, "selling_price"),
+            CompletionDate = GetNullableDateTime(reader, "completion_date"),
+            UsageNotes = GetNullableString(reader, "usage_notes"),
+            Photos = DeserializeJsonArray(GetNullableString(reader, "photos_json")),
+            CustomerId = GetNullableGuid(reader, "customer_id"),
+            CustomerName = GetNullableString(reader, "customer_name"),
+            SoldAt = GetNullableDateTime(reader, "sold_at"),
+            CreatedAtUtc = GetDateTime(reader, "created_at_utc"),
+            UpdatedAtUtc = GetDateTime(reader, "updated_at_utc"),
+        };
+    }
+
+    private static string SerializeJsonArray(IReadOnlyList<string>? values)
+    {
+        var normalized = values?
+            .Where(value => !string.IsNullOrWhiteSpace(value))
+            .Select(value => value.Trim())
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList() ?? [];
+
+        return JsonSerializer.Serialize(normalized);
+    }
+
+    private static IReadOnlyList<string> DeserializeJsonArray(string? raw)
+    {
+        if (string.IsNullOrWhiteSpace(raw))
+        {
+            return [];
+        }
+
+        try
+        {
+            var values = JsonSerializer.Deserialize<List<string>>(raw);
+            return values?
+                .Where(value => !string.IsNullOrWhiteSpace(value))
+                .Select(value => value.Trim())
+                .ToList() ?? [];
+        }
+        catch
+        {
+            return [];
+        }
+    }
+
+    private static object DbNullIfEmpty(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return DBNull.Value;
+        }
+
+        return value.Trim();
+    }
+
+    private static object DbValue<T>(T? value) where T : struct
+    {
+        return value.HasValue ? value.Value : DBNull.Value;
+    }
+
+    private static string NormalizeRequired(string? value, string message)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            throw new ArgumentException(message);
+        }
+
+        return value.Trim();
+    }
+
+    private static (int Limit, int Offset) NormalizePaging(int limit, int offset)
+    {
+        return (Math.Clamp(limit, 1, 200), Math.Max(offset, 0));
+    }
+
+    private static int GetOrdinal(SqlDataReader reader, string columnName) => reader.GetOrdinal(columnName);
+
+    private static string GetString(SqlDataReader reader, string columnName)
+    {
+        var ordinal = GetOrdinal(reader, columnName);
+        return reader.IsDBNull(ordinal) ? string.Empty : Convert.ToString(reader.GetValue(ordinal)) ?? string.Empty;
+    }
+
+    private static string? GetNullableString(SqlDataReader reader, string columnName)
+    {
+        var ordinal = GetOrdinal(reader, columnName);
+        if (reader.IsDBNull(ordinal))
+        {
+            return null;
+        }
+
+        return Convert.ToString(reader.GetValue(ordinal));
+    }
+
+    private static int GetInt32(SqlDataReader reader, string columnName)
+    {
+        var ordinal = GetOrdinal(reader, columnName);
+        if (reader.IsDBNull(ordinal))
+        {
+            return 0;
+        }
+
+        return Convert.ToInt32(reader.GetValue(ordinal));
+    }
+
+    private static int? GetNullableInt32(SqlDataReader reader, string columnName)
+    {
+        var ordinal = GetOrdinal(reader, columnName);
+        if (reader.IsDBNull(ordinal))
+        {
+            return null;
+        }
+
+        return Convert.ToInt32(reader.GetValue(ordinal));
+    }
+
+    private static decimal GetDecimal(SqlDataReader reader, string columnName)
+    {
+        var ordinal = GetOrdinal(reader, columnName);
+        if (reader.IsDBNull(ordinal))
+        {
+            return 0m;
+        }
+
+        return Convert.ToDecimal(reader.GetValue(ordinal));
+    }
+
+    private static DateTime GetDateTime(SqlDataReader reader, string columnName)
+    {
+        var ordinal = GetOrdinal(reader, columnName);
+        if (reader.IsDBNull(ordinal))
+        {
+            return DateTime.UtcNow;
+        }
+
+        return Convert.ToDateTime(reader.GetValue(ordinal));
+    }
+
+    private static DateTime? GetNullableDateTime(SqlDataReader reader, string columnName)
+    {
+        var ordinal = GetOrdinal(reader, columnName);
+        if (reader.IsDBNull(ordinal))
+        {
+            return null;
+        }
+
+        return Convert.ToDateTime(reader.GetValue(ordinal));
+    }
+
+    private static Guid GetGuid(SqlDataReader reader, string columnName)
+    {
+        var ordinal = GetOrdinal(reader, columnName);
+        if (reader.IsDBNull(ordinal))
+        {
+            return Guid.Empty;
+        }
+
+        var value = reader.GetValue(ordinal);
+        return value is Guid guid ? guid : Guid.Parse(Convert.ToString(value) ?? Guid.Empty.ToString());
+    }
+
+    private static Guid? GetNullableGuid(SqlDataReader reader, string columnName)
+    {
+        var ordinal = GetOrdinal(reader, columnName);
+        if (reader.IsDBNull(ordinal))
+        {
+            return null;
+        }
+
+        var value = reader.GetValue(ordinal);
+        if (value is Guid guid)
+        {
+            return guid;
+        }
+
+        return Guid.Parse(Convert.ToString(value) ?? Guid.Empty.ToString());
+    }
+
+    private sealed class SoldProjectRow
+    {
+        public Guid? CustomerId { get; init; }
+        public string? CustomerName { get; init; }
+        public decimal SellingPrice { get; init; }
+        public decimal TotalCost { get; init; }
+        public DateTime? SoldAtUtc { get; init; }
+        public DateTime CreatedAtUtc { get; init; }
+    }
+}

--- a/backend/Services/NoopCustomerManufacturingSqlService.cs
+++ b/backend/Services/NoopCustomerManufacturingSqlService.cs
@@ -1,0 +1,62 @@
+using backend.Models;
+
+namespace backend.Services;
+
+public sealed class NoopCustomerManufacturingSqlService : ICustomerManufacturingSqlService
+{
+    public Task<PagedResponse<CustomerResponse>> GetCustomersAsync(string? search, int limit, int offset, CancellationToken cancellationToken = default)
+        => Task.FromResult(new PagedResponse<CustomerResponse>([], 0, Math.Clamp(limit, 1, 200), Math.Max(offset, 0)));
+
+    public Task<CustomerResponse?> GetCustomerByIdAsync(Guid customerId, CancellationToken cancellationToken = default)
+        => Task.FromResult<CustomerResponse?>(null);
+
+    public Task<CustomerResponse> CreateCustomerAsync(CustomerUpsertRequest request, CancellationToken cancellationToken = default)
+        => Task.FromException<CustomerResponse>(new InvalidOperationException("SQL connection is not configured."));
+
+    public Task<CustomerResponse?> UpdateCustomerAsync(Guid customerId, CustomerUpsertRequest request, CancellationToken cancellationToken = default)
+        => Task.FromResult<CustomerResponse?>(null);
+
+    public Task<bool> DeleteCustomerAsync(Guid customerId, CancellationToken cancellationToken = default)
+        => Task.FromResult(false);
+
+    public Task<bool> AppendCustomerNoteAsync(Guid customerId, string note, CancellationToken cancellationToken = default)
+        => Task.FromResult(false);
+
+    public Task<IReadOnlyList<CustomerActivityResponse>> GetCustomerActivityAsync(Guid customerId, int limit, CancellationToken cancellationToken = default)
+        => Task.FromResult<IReadOnlyList<CustomerActivityResponse>>([]);
+
+    public Task<PagedResponse<ManufacturingProjectSummaryResponse>> GetManufacturingProjectsAsync(
+        string? search,
+        string? status,
+        Guid? customerId,
+        int limit,
+        int offset,
+        CancellationToken cancellationToken = default)
+        => Task.FromResult(new PagedResponse<ManufacturingProjectSummaryResponse>([], 0, Math.Clamp(limit, 1, 200), Math.Max(offset, 0)));
+
+    public Task<ManufacturingProjectDetailResponse?> GetManufacturingProjectByIdAsync(int projectId, CancellationToken cancellationToken = default)
+        => Task.FromResult<ManufacturingProjectDetailResponse?>(null);
+
+    public Task<ManufacturingProjectDetailResponse> CreateManufacturingProjectAsync(
+        ManufacturingProjectUpsertRequest request,
+        CancellationToken cancellationToken = default)
+        => Task.FromException<ManufacturingProjectDetailResponse>(new InvalidOperationException("SQL connection is not configured."));
+
+    public Task<ManufacturingProjectDetailResponse?> UpdateManufacturingProjectAsync(
+        int projectId,
+        ManufacturingProjectUpsertRequest request,
+        CancellationToken cancellationToken = default)
+        => Task.FromResult<ManufacturingProjectDetailResponse?>(null);
+
+    public Task<bool> DeleteManufacturingProjectAsync(int projectId, CancellationToken cancellationToken = default)
+        => Task.FromResult(false);
+
+    public Task<AnalyticsOverviewResponse> GetAnalyticsAsync(CancellationToken cancellationToken = default)
+        => Task.FromResult(new AnalyticsOverviewResponse
+        {
+            CurrentMonth = new AnalyticsCurrentMonthResponse
+            {
+                StartDateUtc = new DateTime(DateTime.UtcNow.Year, DateTime.UtcNow.Month, 1, 0, 0, 0, DateTimeKind.Utc)
+            }
+        });
+}

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -82,3 +82,182 @@ export interface PagedResponse<T> {
   limit: number
   offset: number
 }
+
+export interface Customer {
+  id: string
+  name: string
+  nickname: string | null
+  email: string | null
+  phone: string | null
+  address: string | null
+  notes: string | null
+  photoUrl: string | null
+  customerSince: string | null
+  createdAtUtc: string
+  updatedAtUtc: string
+  totalSpent: number
+  purchaseCount: number
+}
+
+export interface CustomerActivity {
+  id: number
+  projectId: number
+  manufacturingCode: string
+  pieceName: string
+  status: string
+  activityAtUtc: string
+  craftsmanName: string | null
+  notes: string | null
+}
+
+export interface CustomerUpsertRequest {
+  name: string
+  nickname?: string | null
+  email?: string | null
+  phone?: string | null
+  address?: string | null
+  notes?: string | null
+  photoUrl?: string | null
+  customerSince?: string | null
+}
+
+export interface ManufacturingGemstone {
+  id: number
+  inventoryItemId: number | null
+  gemstoneCode: string | null
+  gemstoneType: string | null
+  piecesUsed: number
+  weightUsedCt: number
+  lineCost: number
+  notes: string | null
+}
+
+export interface ManufacturingActivityLog {
+  id: number
+  status: string
+  activityAtUtc: string
+  craftsmanName: string | null
+  notes: string | null
+}
+
+export interface ManufacturingProjectSummary {
+  id: number
+  manufacturingCode: string
+  pieceName: string
+  pieceType: string | null
+  designDate: string | null
+  designerName: string | null
+  status: string
+  craftsmanName: string | null
+  metalPlating: string[]
+  settingCost: number
+  diamondCost: number
+  gemstoneCost: number
+  totalCost: number
+  sellingPrice: number
+  completionDate: string | null
+  customerId: string | null
+  customerName: string | null
+  soldAt: string | null
+  createdAtUtc: string
+  updatedAtUtc: string
+  gemstoneCount: number
+}
+
+export interface ManufacturingProjectDetail {
+  id: number
+  manufacturingCode: string
+  pieceName: string
+  pieceType: string | null
+  designDate: string | null
+  designerName: string | null
+  status: string
+  craftsmanName: string | null
+  metalPlating: string[]
+  metalPlatingNotes: string | null
+  settingCost: number
+  diamondCost: number
+  gemstoneCost: number
+  totalCost: number
+  sellingPrice: number
+  completionDate: string | null
+  usageNotes: string | null
+  photos: string[]
+  customerId: string | null
+  customerName: string | null
+  soldAt: string | null
+  createdAtUtc: string
+  updatedAtUtc: string
+  gemstones: ManufacturingGemstone[]
+  activityLog: ManufacturingActivityLog[]
+}
+
+export interface ManufacturingGemstoneUpsertRequest {
+  inventoryItemId?: number | null
+  gemstoneCode?: string | null
+  gemstoneType?: string | null
+  piecesUsed?: number | null
+  weightUsedCt?: number | null
+  lineCost?: number | null
+  notes?: string | null
+}
+
+export interface ManufacturingProjectUpsertRequest {
+  manufacturingCode?: string | null
+  pieceName?: string | null
+  pieceType?: string | null
+  designDate?: string | null
+  designerName?: string | null
+  status?: string | null
+  craftsmanName?: string | null
+  metalPlating?: string[] | null
+  metalPlatingNotes?: string | null
+  settingCost?: number | null
+  diamondCost?: number | null
+  gemstoneCost?: number | null
+  totalCost?: number | null
+  sellingPrice?: number | null
+  completionDate?: string | null
+  usageNotes?: string | null
+  photos?: string[] | null
+  customerId?: string | null
+  soldAt?: string | null
+  gemstones?: ManufacturingGemstoneUpsertRequest[] | null
+  activityNote?: string | null
+}
+
+export interface AnalyticsCurrentMonth {
+  revenue: number
+  transactions: number
+  startDateUtc: string
+}
+
+export interface AnalyticsTotals {
+  revenue: number
+  orders: number
+  avgOrderValue: number
+  customers: number
+  customersWithPurchases: number
+}
+
+export interface AnalyticsMonthlyRevenuePoint {
+  month: string
+  revenue: number
+  customers: number
+  orders: number
+}
+
+export interface AnalyticsTopCustomerPoint {
+  customerId: string
+  customerName: string
+  totalSpent: number
+  purchases: number
+  lastPurchaseUtc: string
+}
+
+export interface AnalyticsOverview {
+  currentMonth: AnalyticsCurrentMonth
+  totals: AnalyticsTotals
+  monthlyRevenue: AnalyticsMonthlyRevenuePoint[]
+  topCustomers: AnalyticsTopCustomerPoint[]
+}

--- a/frontend/src/components/dashboard/AnalyticsPanel.tsx
+++ b/frontend/src/components/dashboard/AnalyticsPanel.tsx
@@ -1,0 +1,156 @@
+import { useEffect, useState } from 'react'
+import { getAnalyticsOverview } from '../../api/client'
+import type { AnalyticsOverview } from '../../api/types'
+
+function formatCurrency(value: number): string {
+  return new Intl.NumberFormat('th-TH', {
+    style: 'currency',
+    currency: 'THB',
+    maximumFractionDigits: 0
+  }).format(value)
+}
+
+function formatDate(raw: string): string {
+  const parsed = new Date(raw)
+  if (Number.isNaN(parsed.getTime())) {
+    return '-'
+  }
+
+  return parsed.toLocaleDateString('en-GB', {
+    day: '2-digit',
+    month: 'short',
+    year: 'numeric'
+  })
+}
+
+export function AnalyticsPanel() {
+  const [isLoading, setIsLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [analytics, setAnalytics] = useState<AnalyticsOverview | null>(null)
+
+  useEffect(() => {
+    let cancelled = false
+
+    setIsLoading(true)
+    setError(null)
+
+    void getAnalyticsOverview()
+      .then(result => {
+        if (!cancelled) {
+          setAnalytics(result)
+        }
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setError('Unable to load analytics overview.')
+        }
+      })
+      .finally(() => {
+        if (!cancelled) {
+          setIsLoading(false)
+        }
+      })
+
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  if (isLoading) {
+    return (
+      <section className="content-card">
+        <p className="panel-placeholder">Loading analytics...</p>
+      </section>
+    )
+  }
+
+  if (error || !analytics) {
+    return (
+      <section className="content-card">
+        <p className="error-banner">{error ?? 'Analytics data unavailable.'}</p>
+      </section>
+    )
+  }
+
+  return (
+    <>
+      <section className="stats-grid">
+        <article>
+          <h3>This Month Revenue</h3>
+          <strong>{formatCurrency(analytics.currentMonth.revenue)}</strong>
+        </article>
+        <article>
+          <h3>This Month Sales</h3>
+          <strong>{analytics.currentMonth.transactions}</strong>
+        </article>
+        <article>
+          <h3>Total Customers</h3>
+          <strong>{analytics.totals.customers}</strong>
+        </article>
+        <article>
+          <h3>Average Order Value</h3>
+          <strong>{formatCurrency(analytics.totals.avgOrderValue)}</strong>
+        </article>
+      </section>
+
+      <section className="content-card">
+        <div className="card-head">
+          <div>
+            <h3>Revenue Trend (Last 6 Months)</h3>
+            <p>Monthly aggregate based on sold manufacturing records.</p>
+          </div>
+        </div>
+
+        <div className="usage-table-wrap">
+          <table className="usage-table">
+            <thead>
+              <tr>
+                <th>Month</th>
+                <th>Revenue</th>
+                <th>Customers</th>
+                <th>Orders</th>
+              </tr>
+            </thead>
+            <tbody>
+              {analytics.monthlyRevenue.map(point => (
+                <tr key={point.month}>
+                  <td>{point.month}</td>
+                  <td>{formatCurrency(point.revenue)}</td>
+                  <td>{point.customers}</td>
+                  <td>{point.orders}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      <section className="content-card">
+        <div className="card-head">
+          <div>
+            <h3>Top Customers</h3>
+            <p>Highest lifetime purchase value.</p>
+          </div>
+        </div>
+
+        {analytics.topCustomers.length === 0 ? (
+          <p className="panel-placeholder">No sold customer data yet.</p>
+        ) : (
+          <div className="activity-list">
+            {analytics.topCustomers.map(customer => (
+              <article key={customer.customerId}>
+                <p>
+                  <strong>{customer.customerName}</strong>
+                  {' • '}
+                  {customer.purchases} purchases
+                </p>
+                <p>{formatCurrency(customer.totalSpent)}</p>
+                <p>Last purchase: {formatDate(customer.lastPurchaseUtc)}</p>
+              </article>
+            ))}
+          </div>
+        )}
+      </section>
+    </>
+  )
+}

--- a/frontend/src/components/dashboard/CustomersPanel.tsx
+++ b/frontend/src/components/dashboard/CustomersPanel.tsx
@@ -1,0 +1,309 @@
+import { useEffect, useState } from 'react'
+import { addCustomerNote, createCustomer, getCustomer, getCustomerActivity, getCustomers } from '../../api/client'
+import type { Customer, CustomerActivity } from '../../api/types'
+
+function formatCurrency(value: number): string {
+  return new Intl.NumberFormat('th-TH', {
+    style: 'currency',
+    currency: 'THB',
+    maximumFractionDigits: 0
+  }).format(value)
+}
+
+function formatDate(raw: string | null | undefined): string {
+  if (!raw) {
+    return '-'
+  }
+
+  const parsed = new Date(raw)
+  if (Number.isNaN(parsed.getTime())) {
+    return raw
+  }
+
+  return parsed.toLocaleDateString('en-GB', {
+    day: '2-digit',
+    month: 'short',
+    year: 'numeric'
+  })
+}
+
+interface CustomerDraft {
+  name: string
+  nickname: string
+  email: string
+  phone: string
+  address: string
+  notes: string
+}
+
+const EMPTY_CUSTOMER_DRAFT: CustomerDraft = {
+  name: '',
+  nickname: '',
+  email: '',
+  phone: '',
+  address: '',
+  notes: ''
+}
+
+export function CustomersPanel() {
+  const [search, setSearch] = useState('')
+  const [customers, setCustomers] = useState<Customer[]>([])
+  const [totalCount, setTotalCount] = useState(0)
+  const [isLoading, setIsLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  const [selectedCustomer, setSelectedCustomer] = useState<Customer | null>(null)
+  const [selectedActivity, setSelectedActivity] = useState<CustomerActivity[]>([])
+  const [noteDraft, setNoteDraft] = useState('')
+
+  const [isCreating, setIsCreating] = useState(false)
+  const [draft, setDraft] = useState<CustomerDraft>(EMPTY_CUSTOMER_DRAFT)
+  const [isSaving, setIsSaving] = useState(false)
+
+  async function loadCustomers(currentSearch: string) {
+    setIsLoading(true)
+    setError(null)
+
+    try {
+      const page = await getCustomers({
+        search: currentSearch,
+        limit: 120,
+        offset: 0
+      })
+
+      setCustomers(page.items)
+      setTotalCount(page.totalCount)
+    } catch {
+      setError('Unable to load customers.')
+    } finally {
+      setIsLoading(false)
+    }
+  }
+
+  useEffect(() => {
+    void loadCustomers(search)
+  }, [search])
+
+  async function openCustomer(id: string) {
+    setError(null)
+    try {
+      const [customer, activity] = await Promise.all([
+        getCustomer(id),
+        getCustomerActivity(id, 100)
+      ])
+      setSelectedCustomer(customer)
+      setSelectedActivity(activity)
+    } catch {
+      setError('Unable to load selected customer profile.')
+    }
+  }
+
+  async function handleCreate() {
+    if (!draft.name.trim()) {
+      setError('Customer name is required.')
+      return
+    }
+
+    setIsSaving(true)
+    setError(null)
+
+    try {
+      const created = await createCustomer({
+        name: draft.name.trim(),
+        nickname: draft.nickname.trim() || null,
+        email: draft.email.trim() || null,
+        phone: draft.phone.trim() || null,
+        address: draft.address.trim() || null,
+        notes: draft.notes.trim() || null
+      })
+
+      setDraft(EMPTY_CUSTOMER_DRAFT)
+      setIsCreating(false)
+      await loadCustomers(search)
+      await openCustomer(created.id)
+    } catch {
+      setError('Unable to create customer.')
+    } finally {
+      setIsSaving(false)
+    }
+  }
+
+  async function handleAddNote() {
+    if (!selectedCustomer || !noteDraft.trim()) {
+      return
+    }
+
+    setIsSaving(true)
+    setError(null)
+
+    try {
+      const maybeUpdated = await addCustomerNote(selectedCustomer.id, noteDraft.trim())
+      const [activity] = await Promise.all([
+        getCustomerActivity(selectedCustomer.id, 100),
+        loadCustomers(search)
+      ])
+
+      if (maybeUpdated) {
+        setSelectedCustomer(maybeUpdated)
+      } else {
+        const refreshed = await getCustomer(selectedCustomer.id)
+        setSelectedCustomer(refreshed)
+      }
+
+      setSelectedActivity(activity)
+      setNoteDraft('')
+    } catch {
+      setError('Unable to append customer note.')
+    } finally {
+      setIsSaving(false)
+    }
+  }
+
+  return (
+    <>
+      <section className="content-card">
+        <div className="card-head">
+          <div>
+            <h3>Customer Information</h3>
+            <p>{totalCount.toLocaleString()} customer profiles with spend history</p>
+          </div>
+          <button type="button" className="primary-btn" onClick={() => setIsCreating(current => !current)}>
+            {isCreating ? 'Cancel' : 'New Customer'}
+          </button>
+        </div>
+
+        {error ? <p className="error-banner">{error}</p> : null}
+
+      {isCreating ? (
+          <div className="crm-form-grid">
+            <label>
+              Name
+              <input value={draft.name} onChange={event => setDraft(current => ({ ...current, name: event.target.value }))} />
+            </label>
+            <label>
+              Nickname
+              <input value={draft.nickname} onChange={event => setDraft(current => ({ ...current, nickname: event.target.value }))} />
+            </label>
+            <label>
+              Email
+              <input value={draft.email} onChange={event => setDraft(current => ({ ...current, email: event.target.value }))} />
+            </label>
+            <label>
+              Phone
+              <input value={draft.phone} onChange={event => setDraft(current => ({ ...current, phone: event.target.value }))} />
+            </label>
+            <label className="crm-form-span">
+              Address
+              <input value={draft.address} onChange={event => setDraft(current => ({ ...current, address: event.target.value }))} />
+            </label>
+            <label className="crm-form-span">
+              Notes
+              <textarea rows={3} value={draft.notes} onChange={event => setDraft(current => ({ ...current, notes: event.target.value }))} />
+            </label>
+            <div className="crm-form-actions crm-form-span">
+              <button type="button" className="secondary-btn" onClick={() => setDraft(EMPTY_CUSTOMER_DRAFT)} disabled={isSaving}>
+                Reset
+              </button>
+              <button type="button" className="primary-btn" onClick={() => void handleCreate()} disabled={isSaving}>
+                {isSaving ? 'Saving...' : 'Save Customer'}
+              </button>
+            </div>
+          </div>
+        ) : null}
+
+        <div className="filter-grid single-row-filter">
+          <input value={search} onChange={event => setSearch(event.target.value)} placeholder="Search by name, nickname, email, or phone" />
+        </div>
+
+        {isLoading ? (
+          <p className="panel-placeholder">Loading customer list...</p>
+        ) : (
+          <div className="usage-table-wrap">
+            <table className="usage-table">
+              <thead>
+                <tr>
+                  <th>Name</th>
+                  <th>Email</th>
+                  <th>Phone</th>
+                  <th>Total Spent</th>
+                  <th>Purchases</th>
+                </tr>
+              </thead>
+              <tbody>
+                {customers.map(customer => (
+                  <tr key={customer.id} onClick={() => void openCustomer(customer.id)}>
+                    <td>
+                      <strong>{customer.name}</strong>
+                      {customer.nickname ? <p className="inline-subtext">{customer.nickname}</p> : null}
+                    </td>
+                    <td>{customer.email ?? '-'}</td>
+                    <td>{customer.phone ?? '-'}</td>
+                    <td>{formatCurrency(customer.totalSpent)}</td>
+                    <td>{customer.purchaseCount}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </section>
+
+      {selectedCustomer ? (
+        <section className="detail-drawer">
+          <div className="drawer-head">
+            <h3>{selectedCustomer.name}</h3>
+            <button type="button" className="secondary-btn" onClick={() => setSelectedCustomer(null)}>
+              Close
+            </button>
+          </div>
+
+          <div className="drawer-grid">
+            <p>
+              <strong>Email:</strong> {selectedCustomer.email ?? '-'}
+            </p>
+            <p>
+              <strong>Phone:</strong> {selectedCustomer.phone ?? '-'}
+            </p>
+            <p>
+              <strong>Customer Since:</strong> {formatDate(selectedCustomer.customerSince)}
+            </p>
+            <p>
+              <strong>Total Spent:</strong> {formatCurrency(selectedCustomer.totalSpent)}
+            </p>
+          </div>
+
+          <div className="crm-note-editor">
+            <h4>Add Note</h4>
+            <textarea rows={3} value={noteDraft} onChange={event => setNoteDraft(event.target.value)} placeholder="Add relationship or order notes..." />
+            <div className="crm-form-actions">
+              <button type="button" className="primary-btn" onClick={() => void handleAddNote()} disabled={isSaving || !noteDraft.trim()}>
+                {isSaving ? 'Saving...' : 'Append Note'}
+              </button>
+            </div>
+          </div>
+
+          <div className="usage-lines">
+            <h4>Customer Activity</h4>
+            {selectedActivity.length === 0 ? (
+              <p className="panel-placeholder">No activity logged yet.</p>
+            ) : (
+              <div className="activity-list">
+                {selectedActivity.map(activity => (
+                  <article key={activity.id}>
+                    <p>
+                      <strong>{activity.status.replace(/_/g, ' ')}</strong>
+                      {' • '}
+                      {formatDate(activity.activityAtUtc)}
+                    </p>
+                    <p>{activity.manufacturingCode} / {activity.pieceName}</p>
+                    {activity.notes ? <p>{activity.notes}</p> : null}
+                  </article>
+                ))}
+              </div>
+            )}
+          </div>
+        </section>
+      ) : null}
+    </>
+  )
+}

--- a/frontend/src/components/dashboard/ManufacturingPanel.tsx
+++ b/frontend/src/components/dashboard/ManufacturingPanel.tsx
@@ -1,0 +1,404 @@
+import { useEffect, useState } from 'react'
+import {
+  createManufacturingProject,
+  getManufacturingProject,
+  getManufacturingProjects,
+  updateManufacturingProject
+} from '../../api/client'
+import type { ManufacturingProjectDetail, ManufacturingProjectSummary } from '../../api/types'
+
+const STATUS_OPTIONS = [
+  'approved',
+  'sent_to_craftsman',
+  'internal_setting_qc',
+  'diamond_sorting',
+  'stone_setting',
+  'plating',
+  'final_piece_qc',
+  'complete_piece',
+  'ready_for_sale',
+  'sold'
+]
+
+const PIECE_TYPES = ['earrings', 'bracelet', 'choker', 'necklace', 'brooch', 'ring', 'pendant', 'other']
+
+function labelize(value: string | null | undefined): string {
+  if (!value) {
+    return '-'
+  }
+  return value
+    .split('_')
+    .filter(Boolean)
+    .map(part => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(' ')
+}
+
+function formatCurrency(value: number): string {
+  return new Intl.NumberFormat('th-TH', {
+    style: 'currency',
+    currency: 'THB',
+    maximumFractionDigits: 0
+  }).format(value)
+}
+
+function formatDate(raw: string | null | undefined): string {
+  if (!raw) {
+    return '-'
+  }
+
+  const parsed = new Date(raw)
+  if (Number.isNaN(parsed.getTime())) {
+    return raw
+  }
+
+  return parsed.toLocaleDateString('en-GB', {
+    day: '2-digit',
+    month: 'short',
+    year: 'numeric'
+  })
+}
+
+interface ProjectDraft {
+  manufacturingCode: string
+  pieceName: string
+  pieceType: string
+  status: string
+  designerName: string
+  craftsmanName: string
+  sellingPrice: string
+  totalCost: string
+  metalPlating: string
+  usageNotes: string
+}
+
+const EMPTY_DRAFT: ProjectDraft = {
+  manufacturingCode: '',
+  pieceName: '',
+  pieceType: 'necklace',
+  status: 'approved',
+  designerName: '',
+  craftsmanName: '',
+  sellingPrice: '0',
+  totalCost: '0',
+  metalPlating: '',
+  usageNotes: ''
+}
+
+export function ManufacturingPanel() {
+  const [search, setSearch] = useState('')
+  const [statusFilter, setStatusFilter] = useState('all')
+  const [records, setRecords] = useState<ManufacturingProjectSummary[]>([])
+  const [totalCount, setTotalCount] = useState(0)
+  const [isLoading, setIsLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  const [selected, setSelected] = useState<ManufacturingProjectDetail | null>(null)
+  const [selectedStatus, setSelectedStatus] = useState('')
+
+  const [isCreating, setIsCreating] = useState(false)
+  const [draft, setDraft] = useState<ProjectDraft>(EMPTY_DRAFT)
+  const [isSaving, setIsSaving] = useState(false)
+
+  async function loadRecords(currentSearch: string, currentStatus: string) {
+    setIsLoading(true)
+    setError(null)
+
+    try {
+      const page = await getManufacturingProjects({
+        search: currentSearch,
+        status: currentStatus,
+        limit: 150,
+        offset: 0
+      })
+      setRecords(page.items)
+      setTotalCount(page.totalCount)
+    } catch {
+      setError('Unable to load manufacturing records.')
+    } finally {
+      setIsLoading(false)
+    }
+  }
+
+  useEffect(() => {
+    void loadRecords(search, statusFilter)
+  }, [search, statusFilter])
+
+  async function openDetail(projectId: number) {
+    setError(null)
+    try {
+      const detail = await getManufacturingProject(projectId)
+      setSelected(detail)
+      setSelectedStatus(detail.status)
+    } catch {
+      setError('Unable to load selected manufacturing project.')
+    }
+  }
+
+  async function handleCreate() {
+    if (!draft.manufacturingCode.trim() || !draft.pieceName.trim()) {
+      setError('Manufacturing code and piece name are required.')
+      return
+    }
+
+    setIsSaving(true)
+    setError(null)
+
+    try {
+      const created = await createManufacturingProject({
+        manufacturingCode: draft.manufacturingCode.trim(),
+        pieceName: draft.pieceName.trim(),
+        pieceType: draft.pieceType,
+        status: draft.status,
+        designerName: draft.designerName.trim() || null,
+        craftsmanName: draft.craftsmanName.trim() || null,
+        sellingPrice: Number(draft.sellingPrice) || 0,
+        totalCost: Number(draft.totalCost) || 0,
+        metalPlating: draft.metalPlating
+          .split(',')
+          .map(item => item.trim())
+          .filter(item => item.length > 0),
+        usageNotes: draft.usageNotes.trim() || null,
+        gemstones: []
+      })
+
+      setDraft(EMPTY_DRAFT)
+      setIsCreating(false)
+      await loadRecords(search, statusFilter)
+      setSelected(created)
+      setSelectedStatus(created.status)
+    } catch {
+      setError('Unable to create manufacturing project.')
+    } finally {
+      setIsSaving(false)
+    }
+  }
+
+  async function handleUpdateStatus() {
+    if (!selected || !selectedStatus) {
+      return
+    }
+
+    setIsSaving(true)
+    setError(null)
+
+    try {
+      const updated = await updateManufacturingProject(selected.id, {
+        status: selectedStatus,
+        activityNote: `Status updated from dashboard to ${selectedStatus}`
+      })
+
+      setSelected(updated)
+      await loadRecords(search, statusFilter)
+    } catch {
+      setError('Unable to update project status.')
+    } finally {
+      setIsSaving(false)
+    }
+  }
+
+  return (
+    <>
+      <section className="content-card">
+        <div className="card-head">
+          <div>
+            <h3>Manufacturing Records</h3>
+            <p>{totalCount.toLocaleString()} projects across production workflow stages</p>
+          </div>
+          <button type="button" className="primary-btn" onClick={() => setIsCreating(current => !current)}>
+            {isCreating ? 'Cancel' : 'New Project'}
+          </button>
+        </div>
+
+        {error ? <p className="error-banner">{error}</p> : null}
+
+        <div className="filter-grid">
+          <input value={search} onChange={event => setSearch(event.target.value)} placeholder="Search code, piece, designer, craftsman" />
+          <select value={statusFilter} onChange={event => setStatusFilter(event.target.value)}>
+            <option value="all">All statuses</option>
+            <option value="in_production">In production</option>
+            {STATUS_OPTIONS.map(status => (
+              <option key={status} value={status}>
+                {labelize(status)}
+              </option>
+            ))}
+          </select>
+          <div />
+        </div>
+
+        {isCreating ? (
+          <div className="crm-form-grid">
+            <label>
+              Manufacturing Code
+              <input value={draft.manufacturingCode} onChange={event => setDraft(current => ({ ...current, manufacturingCode: event.target.value }))} />
+            </label>
+            <label>
+              Piece Name
+              <input value={draft.pieceName} onChange={event => setDraft(current => ({ ...current, pieceName: event.target.value }))} />
+            </label>
+            <label>
+              Piece Type
+              <select value={draft.pieceType} onChange={event => setDraft(current => ({ ...current, pieceType: event.target.value }))}>
+                {PIECE_TYPES.map(type => (
+                  <option key={type} value={type}>{labelize(type)}</option>
+                ))}
+              </select>
+            </label>
+            <label>
+              Status
+              <select value={draft.status} onChange={event => setDraft(current => ({ ...current, status: event.target.value }))}>
+                {STATUS_OPTIONS.map(status => (
+                  <option key={status} value={status}>{labelize(status)}</option>
+                ))}
+              </select>
+            </label>
+            <label>
+              Designer
+              <input value={draft.designerName} onChange={event => setDraft(current => ({ ...current, designerName: event.target.value }))} />
+            </label>
+            <label>
+              Craftsman
+              <input value={draft.craftsmanName} onChange={event => setDraft(current => ({ ...current, craftsmanName: event.target.value }))} />
+            </label>
+            <label>
+              Selling Price (THB)
+              <input type="number" value={draft.sellingPrice} onChange={event => setDraft(current => ({ ...current, sellingPrice: event.target.value }))} />
+            </label>
+            <label>
+              Total Cost (THB)
+              <input type="number" value={draft.totalCost} onChange={event => setDraft(current => ({ ...current, totalCost: event.target.value }))} />
+            </label>
+            <label className="crm-form-span">
+              Metal Plating (comma separated)
+              <input value={draft.metalPlating} onChange={event => setDraft(current => ({ ...current, metalPlating: event.target.value }))} placeholder="white_gold, rose_gold" />
+            </label>
+            <label className="crm-form-span">
+              Notes
+              <textarea rows={3} value={draft.usageNotes} onChange={event => setDraft(current => ({ ...current, usageNotes: event.target.value }))} />
+            </label>
+            <div className="crm-form-actions crm-form-span">
+              <button type="button" className="secondary-btn" onClick={() => setDraft(EMPTY_DRAFT)} disabled={isSaving}>Reset</button>
+              <button type="button" className="primary-btn" onClick={() => void handleCreate()} disabled={isSaving}>
+                {isSaving ? 'Saving...' : 'Save Project'}
+              </button>
+            </div>
+          </div>
+        ) : null}
+
+        {isLoading ? (
+          <p className="panel-placeholder">Loading manufacturing projects...</p>
+        ) : (
+          <div className="usage-table-wrap">
+            <table className="usage-table">
+              <thead>
+                <tr>
+                  <th>Code</th>
+                  <th>Piece</th>
+                  <th>Status</th>
+                  <th>Designer</th>
+                  <th>Selling Price</th>
+                  <th>Customer</th>
+                </tr>
+              </thead>
+              <tbody>
+                {records.map(record => (
+                  <tr key={record.id} onClick={() => void openDetail(record.id)}>
+                    <td>{record.manufacturingCode}</td>
+                    <td>
+                      <strong>{record.pieceName}</strong>
+                      <p className="inline-subtext">{labelize(record.pieceType)}</p>
+                    </td>
+                    <td>{labelize(record.status)}</td>
+                    <td>{record.designerName ?? '-'}</td>
+                    <td>{formatCurrency(record.sellingPrice)}</td>
+                    <td>{record.customerName ?? '-'}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </section>
+
+      {selected ? (
+        <section className="detail-drawer">
+          <div className="drawer-head">
+            <h3>{selected.manufacturingCode} · {selected.pieceName}</h3>
+            <button type="button" className="secondary-btn" onClick={() => setSelected(null)}>Close</button>
+          </div>
+
+          <div className="drawer-grid">
+            <p><strong>Type:</strong> {labelize(selected.pieceType)}</p>
+            <p><strong>Status:</strong> {labelize(selected.status)}</p>
+            <p><strong>Designer:</strong> {selected.designerName ?? '-'}</p>
+            <p><strong>Craftsman:</strong> {selected.craftsmanName ?? '-'}</p>
+            <p><strong>Selling Price:</strong> {formatCurrency(selected.sellingPrice)}</p>
+            <p><strong>Total Cost:</strong> {formatCurrency(selected.totalCost)}</p>
+            <p><strong>Design Date:</strong> {formatDate(selected.designDate)}</p>
+            <p><strong>Completion Date:</strong> {formatDate(selected.completionDate)}</p>
+            <p><strong>Customer:</strong> {selected.customerName ?? '-'}</p>
+            <p><strong>Sold At:</strong> {formatDate(selected.soldAt)}</p>
+          </div>
+
+          <div className="status-update-row">
+            <select value={selectedStatus} onChange={event => setSelectedStatus(event.target.value)}>
+              {STATUS_OPTIONS.map(status => (
+                <option key={status} value={status}>{labelize(status)}</option>
+              ))}
+            </select>
+            <button type="button" className="primary-btn" onClick={() => void handleUpdateStatus()} disabled={isSaving || selectedStatus === selected.status}>
+              {isSaving ? 'Updating...' : 'Update Status'}
+            </button>
+          </div>
+
+          {selected.usageNotes ? (
+            <div className="usage-lines">
+              <h4>Notes</h4>
+              <p>{selected.usageNotes}</p>
+            </div>
+          ) : null}
+
+          <div className="usage-lines">
+            <h4>Gemstones</h4>
+            {selected.gemstones.length === 0 ? (
+              <p className="panel-placeholder">No gemstones linked yet.</p>
+            ) : (
+              <div className="activity-list">
+                {selected.gemstones.map(gem => (
+                  <article key={gem.id}>
+                    <p>
+                      <strong>{gem.gemstoneCode ?? `#${gem.inventoryItemId ?? '?'}`}</strong>
+                      {' • '}
+                      {gem.gemstoneType ?? 'Unknown'}
+                    </p>
+                    <p>{gem.weightUsedCt} ct / {gem.piecesUsed} pcs</p>
+                    <p>{formatCurrency(gem.lineCost)}</p>
+                  </article>
+                ))}
+              </div>
+            )}
+          </div>
+
+          <div className="usage-lines">
+            <h4>Activity Log</h4>
+            {selected.activityLog.length === 0 ? (
+              <p className="panel-placeholder">No activity entries yet.</p>
+            ) : (
+              <div className="activity-list">
+                {selected.activityLog.map(entry => (
+                  <article key={entry.id}>
+                    <p>
+                      <strong>{labelize(entry.status)}</strong>
+                      {' • '}
+                      {formatDate(entry.activityAtUtc)}
+                    </p>
+                    {entry.notes ? <p>{entry.notes}</p> : null}
+                  </article>
+                ))}
+              </div>
+            )}
+          </div>
+        </section>
+      ) : null}
+    </>
+  )
+}

--- a/frontend/src/components/dashboard/PurchasesPanel.tsx
+++ b/frontend/src/components/dashboard/PurchasesPanel.tsx
@@ -1,0 +1,156 @@
+import { useEffect, useMemo, useState } from 'react'
+import { getManufacturingProjects } from '../../api/client'
+import type { ManufacturingProjectSummary } from '../../api/types'
+
+function formatCurrency(value: number): string {
+  return new Intl.NumberFormat('th-TH', {
+    style: 'currency',
+    currency: 'THB',
+    maximumFractionDigits: 0
+  }).format(value)
+}
+
+function formatDate(raw: string | null | undefined): string {
+  if (!raw) {
+    return '-'
+  }
+
+  const parsed = new Date(raw)
+  if (Number.isNaN(parsed.getTime())) {
+    return raw
+  }
+
+  return parsed.toLocaleDateString('en-GB', {
+    day: '2-digit',
+    month: 'short',
+    year: 'numeric'
+  })
+}
+
+function labelize(value: string | null | undefined): string {
+  if (!value) {
+    return '-'
+  }
+
+  return value
+    .split('_')
+    .filter(Boolean)
+    .map(part => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(' ')
+}
+
+export function PurchasesPanel() {
+  const [search, setSearch] = useState('')
+  const [isLoading, setIsLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [records, setRecords] = useState<ManufacturingProjectSummary[]>([])
+
+  useEffect(() => {
+    let cancelled = false
+
+    setIsLoading(true)
+    setError(null)
+
+    void getManufacturingProjects({
+      status: 'sold',
+      search,
+      limit: 150,
+      offset: 0
+    })
+      .then(page => {
+        if (!cancelled) {
+          setRecords(page.items)
+        }
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setError('Unable to load sold purchases.')
+        }
+      })
+      .finally(() => {
+        if (!cancelled) {
+          setIsLoading(false)
+        }
+      })
+
+    return () => {
+      cancelled = true
+    }
+  }, [search])
+
+  const totals = useMemo(() => {
+    const revenue = records.reduce((sum, record) => sum + record.sellingPrice, 0)
+    const cost = records.reduce((sum, record) => sum + record.totalCost, 0)
+    const profit = revenue - cost
+    const avg = records.length > 0 ? revenue / records.length : 0
+
+    return { revenue, profit, avg }
+  }, [records])
+
+  return (
+    <section className="content-card">
+      <div className="card-head">
+        <div>
+          <h3>Purchase History</h3>
+          <p>{records.length.toLocaleString()} completed sold transactions</p>
+        </div>
+      </div>
+
+      {error ? <p className="error-banner">{error}</p> : null}
+
+      <section className="stats-grid compact-stats">
+        <article>
+          <h3>Total Revenue</h3>
+          <strong>{formatCurrency(totals.revenue)}</strong>
+        </article>
+        <article>
+          <h3>Total Profit</h3>
+          <strong>{formatCurrency(totals.profit)}</strong>
+        </article>
+        <article>
+          <h3>Average Sale</h3>
+          <strong>{formatCurrency(totals.avg)}</strong>
+        </article>
+        <article>
+          <h3>Transactions</h3>
+          <strong>{records.length}</strong>
+        </article>
+      </section>
+
+      <div className="filter-grid single-row-filter">
+        <input value={search} onChange={event => setSearch(event.target.value)} placeholder="Search by customer, code, piece name" />
+      </div>
+
+      {isLoading ? (
+        <p className="panel-placeholder">Loading sold transactions...</p>
+      ) : (
+        <div className="usage-table-wrap">
+          <table className="usage-table">
+            <thead>
+              <tr>
+                <th>Code</th>
+                <th>Piece</th>
+                <th>Type</th>
+                <th>Customer</th>
+                <th>Sold Date</th>
+                <th>Sale Price</th>
+              </tr>
+            </thead>
+            <tbody>
+              {records.map(record => (
+                <tr key={record.id}>
+                  <td>{record.manufacturingCode}</td>
+                  <td>{record.pieceName}</td>
+                  <td>{labelize(record.pieceType)}</td>
+                  <td>{record.customerName ?? '-'}</td>
+                  <td>{formatDate(record.soldAt)}</td>
+                  <td>{formatCurrency(record.sellingPrice)}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </section>
+  )
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -488,6 +488,107 @@ select {
   margin: 0 0 0.4rem;
 }
 
+.compact-stats {
+  margin: 0.85rem 0;
+}
+
+.single-row-filter {
+  margin-bottom: 0.85rem;
+  grid-template-columns: minmax(0, 1fr);
+}
+
+.crm-form-grid {
+  margin: 0.85rem 0 1rem;
+  padding: 0.75rem;
+  border: 1px solid #e2d4bc;
+  border-radius: 12px;
+  background: #fffbf3;
+  display: grid;
+  gap: 0.55rem;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.crm-form-grid label {
+  display: grid;
+  gap: 0.3rem;
+  font-size: 0.82rem;
+  color: var(--ink-700);
+}
+
+.crm-form-grid input,
+.crm-form-grid select,
+.crm-form-grid textarea {
+  border: 1px solid #d7c8b1;
+  border-radius: 8px;
+  padding: 0.48rem 0.56rem;
+  background: #fff;
+  color: var(--ink-900);
+  resize: vertical;
+}
+
+.crm-form-span {
+  grid-column: 1 / -1;
+}
+
+.crm-form-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.45rem;
+}
+
+.inline-subtext {
+  margin: 0.15rem 0 0;
+  color: var(--ink-700);
+  font-size: 0.76rem;
+}
+
+.crm-note-editor {
+  margin-top: 0.8rem;
+}
+
+.crm-note-editor h4 {
+  margin: 0 0 0.4rem;
+}
+
+.crm-note-editor textarea {
+  width: 100%;
+  border: 1px solid #d7c8b1;
+  border-radius: 8px;
+  padding: 0.55rem;
+  background: #fff;
+}
+
+.activity-list {
+  display: grid;
+  gap: 0.42rem;
+}
+
+.activity-list article {
+  border: 1px solid #ebdfcc;
+  border-radius: 10px;
+  padding: 0.5rem 0.6rem;
+  background: #fffdf8;
+}
+
+.activity-list p {
+  margin: 0.12rem 0;
+  font-size: 0.83rem;
+}
+
+.status-update-row {
+  margin-top: 0.8rem;
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+.status-update-row select {
+  border: 1px solid #d7c8b1;
+  border-radius: 8px;
+  padding: 0.48rem 0.56rem;
+  background: #fff;
+}
+
 @media (max-width: 1080px) {
   .auth-shell {
     grid-template-columns: 1fr;
@@ -513,6 +614,10 @@ select {
   }
 
   .drawer-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .crm-form-grid {
     grid-template-columns: 1fr;
   }
 }

--- a/migrations/003_customer_manufacturing_schema.sql
+++ b/migrations/003_customer_manufacturing_schema.sql
@@ -1,0 +1,195 @@
+-- Customer + manufacturing domain schema aligned to the v0 reference prototype.
+
+IF OBJECT_ID('dbo.customers', 'U') IS NULL
+BEGIN
+    CREATE TABLE dbo.customers (
+        id UNIQUEIDENTIFIER NOT NULL PRIMARY KEY DEFAULT NEWID(),
+        name NVARCHAR(180) NOT NULL,
+        nickname NVARCHAR(120) NULL,
+        email NVARCHAR(255) NULL,
+        phone NVARCHAR(64) NULL,
+        address NVARCHAR(400) NULL,
+        notes NVARCHAR(MAX) NULL,
+        photo_url NVARCHAR(1024) NULL,
+        customer_since DATETIME2 NULL,
+        created_at_utc DATETIME2 NOT NULL DEFAULT SYSUTCDATETIME(),
+        updated_at_utc DATETIME2 NOT NULL DEFAULT SYSUTCDATETIME()
+    );
+END
+GO
+
+IF NOT EXISTS (
+    SELECT 1 FROM sys.indexes
+    WHERE object_id = OBJECT_ID('dbo.customers')
+      AND name = 'IX_customers_name'
+)
+BEGIN
+    CREATE INDEX IX_customers_name ON dbo.customers(name);
+END
+GO
+
+IF NOT EXISTS (
+    SELECT 1 FROM sys.indexes
+    WHERE object_id = OBJECT_ID('dbo.customers')
+      AND name = 'IX_customers_email'
+)
+BEGIN
+    CREATE INDEX IX_customers_email ON dbo.customers(email);
+END
+GO
+
+IF OBJECT_ID('dbo.manufacturing_projects', 'U') IS NULL
+BEGIN
+    CREATE TABLE dbo.manufacturing_projects (
+        id INT IDENTITY(1,1) NOT NULL PRIMARY KEY,
+        manufacturing_code NVARCHAR(64) NOT NULL,
+        piece_name NVARCHAR(180) NOT NULL,
+        piece_type NVARCHAR(40) NULL,
+        design_date DATE NULL,
+        designer_name NVARCHAR(120) NULL,
+        status NVARCHAR(40) NOT NULL,
+        craftsman_name NVARCHAR(120) NULL,
+        metal_plating_json NVARCHAR(MAX) NULL,
+        metal_plating_notes NVARCHAR(MAX) NULL,
+        setting_cost DECIMAL(18,2) NOT NULL DEFAULT 0,
+        diamond_cost DECIMAL(18,2) NOT NULL DEFAULT 0,
+        gemstone_cost DECIMAL(18,2) NOT NULL DEFAULT 0,
+        total_cost DECIMAL(18,2) NOT NULL DEFAULT 0,
+        selling_price DECIMAL(18,2) NOT NULL DEFAULT 0,
+        completion_date DATE NULL,
+        usage_notes NVARCHAR(MAX) NULL,
+        photos_json NVARCHAR(MAX) NULL,
+        customer_id UNIQUEIDENTIFIER NULL,
+        sold_at DATETIME2 NULL,
+        created_at_utc DATETIME2 NOT NULL DEFAULT SYSUTCDATETIME(),
+        updated_at_utc DATETIME2 NOT NULL DEFAULT SYSUTCDATETIME(),
+        CONSTRAINT CK_manufacturing_projects_status CHECK (
+            status IN (
+                'approved',
+                'sent_to_craftsman',
+                'internal_setting_qc',
+                'diamond_sorting',
+                'stone_setting',
+                'plating',
+                'final_piece_qc',
+                'complete_piece',
+                'ready_for_sale',
+                'sold'
+            )
+        ),
+        CONSTRAINT FK_manufacturing_projects_customer_id
+            FOREIGN KEY (customer_id)
+            REFERENCES dbo.customers(id)
+            ON DELETE SET NULL
+    );
+END
+GO
+
+IF NOT EXISTS (
+    SELECT 1 FROM sys.indexes
+    WHERE object_id = OBJECT_ID('dbo.manufacturing_projects')
+      AND name = 'UX_manufacturing_projects_code'
+)
+BEGIN
+    CREATE UNIQUE INDEX UX_manufacturing_projects_code
+        ON dbo.manufacturing_projects(manufacturing_code);
+END
+GO
+
+IF NOT EXISTS (
+    SELECT 1 FROM sys.indexes
+    WHERE object_id = OBJECT_ID('dbo.manufacturing_projects')
+      AND name = 'IX_manufacturing_projects_status'
+)
+BEGIN
+    CREATE INDEX IX_manufacturing_projects_status
+        ON dbo.manufacturing_projects(status, updated_at_utc DESC);
+END
+GO
+
+IF NOT EXISTS (
+    SELECT 1 FROM sys.indexes
+    WHERE object_id = OBJECT_ID('dbo.manufacturing_projects')
+      AND name = 'IX_manufacturing_projects_customer_id'
+)
+BEGIN
+    CREATE INDEX IX_manufacturing_projects_customer_id
+        ON dbo.manufacturing_projects(customer_id);
+END
+GO
+
+IF OBJECT_ID('dbo.manufacturing_project_gemstones', 'U') IS NULL
+BEGIN
+    CREATE TABLE dbo.manufacturing_project_gemstones (
+        id INT IDENTITY(1,1) NOT NULL PRIMARY KEY,
+        project_id INT NOT NULL,
+        inventory_item_id INT NULL,
+        gemstone_code NVARCHAR(64) NULL,
+        gemstone_type NVARCHAR(200) NULL,
+        pieces_used DECIMAL(18,4) NOT NULL DEFAULT 0,
+        weight_used_ct DECIMAL(18,4) NOT NULL DEFAULT 0,
+        line_cost DECIMAL(18,2) NOT NULL DEFAULT 0,
+        notes NVARCHAR(MAX) NULL,
+        created_at_utc DATETIME2 NOT NULL DEFAULT SYSUTCDATETIME(),
+        CONSTRAINT FK_manufacturing_project_gemstones_project_id
+            FOREIGN KEY (project_id)
+            REFERENCES dbo.manufacturing_projects(id)
+            ON DELETE CASCADE,
+        CONSTRAINT FK_manufacturing_project_gemstones_inventory_item_id
+            FOREIGN KEY (inventory_item_id)
+            REFERENCES dbo.gem_inventory_items(id)
+            ON DELETE SET NULL
+    );
+END
+GO
+
+IF NOT EXISTS (
+    SELECT 1 FROM sys.indexes
+    WHERE object_id = OBJECT_ID('dbo.manufacturing_project_gemstones')
+      AND name = 'IX_manufacturing_project_gemstones_project_id'
+)
+BEGIN
+    CREATE INDEX IX_manufacturing_project_gemstones_project_id
+        ON dbo.manufacturing_project_gemstones(project_id);
+END
+GO
+
+IF NOT EXISTS (
+    SELECT 1 FROM sys.indexes
+    WHERE object_id = OBJECT_ID('dbo.manufacturing_project_gemstones')
+      AND name = 'IX_manufacturing_project_gemstones_inventory_item_id'
+)
+BEGIN
+    CREATE INDEX IX_manufacturing_project_gemstones_inventory_item_id
+        ON dbo.manufacturing_project_gemstones(inventory_item_id);
+END
+GO
+
+IF OBJECT_ID('dbo.manufacturing_activity_log', 'U') IS NULL
+BEGIN
+    CREATE TABLE dbo.manufacturing_activity_log (
+        id INT IDENTITY(1,1) NOT NULL PRIMARY KEY,
+        project_id INT NOT NULL,
+        status NVARCHAR(40) NOT NULL,
+        activity_at_utc DATETIME2 NOT NULL DEFAULT SYSUTCDATETIME(),
+        craftsman_name NVARCHAR(120) NULL,
+        notes NVARCHAR(MAX) NULL,
+        created_at_utc DATETIME2 NOT NULL DEFAULT SYSUTCDATETIME(),
+        CONSTRAINT FK_manufacturing_activity_log_project_id
+            FOREIGN KEY (project_id)
+            REFERENCES dbo.manufacturing_projects(id)
+            ON DELETE CASCADE
+    );
+END
+GO
+
+IF NOT EXISTS (
+    SELECT 1 FROM sys.indexes
+    WHERE object_id = OBJECT_ID('dbo.manufacturing_activity_log')
+      AND name = 'IX_manufacturing_activity_log_project_id'
+)
+BEGIN
+    CREATE INDEX IX_manufacturing_activity_log_project_id
+        ON dbo.manufacturing_activity_log(project_id, activity_at_utc DESC);
+END
+GO

--- a/tools/db/seed_customer_manufacturing.sql
+++ b/tools/db/seed_customer_manufacturing.sql
@@ -1,0 +1,274 @@
+-- Seed baseline customer + manufacturing demo records for local/testing environments.
+-- Safe to run multiple times; uses deterministic keys and existence checks.
+
+IF NOT EXISTS (SELECT 1 FROM dbo.customers WHERE email = 'vip.nicha@houseofrojanatorn.local')
+BEGIN
+    INSERT INTO dbo.customers (name, nickname, email, phone, address, notes, customer_since)
+    VALUES (
+        N'Nicha Rojanatorn',
+        N'Nicha',
+        N'vip.nicha@houseofrojanatorn.local',
+        N'+66-81-234-5001',
+        N'Bangkok, Thailand',
+        N'VIP collector focused on brooch and necklace commissions.',
+        DATEADD(DAY, -420, SYSUTCDATETIME())
+    );
+END
+GO
+
+IF NOT EXISTS (SELECT 1 FROM dbo.customers WHERE email = 'poranee.chan@houseofrojanatorn.local')
+BEGIN
+    INSERT INTO dbo.customers (name, nickname, email, phone, address, notes, customer_since)
+    VALUES (
+        N'Poranee Chantra',
+        N'Ploy',
+        N'poranee.chan@houseofrojanatorn.local',
+        N'+66-86-520-1188',
+        N'Chiang Mai, Thailand',
+        N'Orders bridal and family legacy pieces.',
+        DATEADD(DAY, -260, SYSUTCDATETIME())
+    );
+END
+GO
+
+IF NOT EXISTS (SELECT 1 FROM dbo.customers WHERE email = 'michael.tan@houseofrojanatorn.local')
+BEGIN
+    INSERT INTO dbo.customers (name, nickname, email, phone, address, notes, customer_since)
+    VALUES (
+        N'Michael Tan',
+        N'Mike',
+        N'michael.tan@houseofrojanatorn.local',
+        N'+65-9123-7788',
+        N'Singapore',
+        N'Prefers modern art-deco style earrings and cufflinks.',
+        DATEADD(DAY, -190, SYSUTCDATETIME())
+    );
+END
+GO
+
+DECLARE @customerNicha UNIQUEIDENTIFIER = (
+    SELECT TOP 1 id FROM dbo.customers WHERE email = 'vip.nicha@houseofrojanatorn.local'
+);
+DECLARE @customerPoranee UNIQUEIDENTIFIER = (
+    SELECT TOP 1 id FROM dbo.customers WHERE email = 'poranee.chan@houseofrojanatorn.local'
+);
+DECLARE @customerMichael UNIQUEIDENTIFIER = (
+    SELECT TOP 1 id FROM dbo.customers WHERE email = 'michael.tan@houseofrojanatorn.local'
+);
+
+IF NOT EXISTS (SELECT 1 FROM dbo.manufacturing_projects WHERE manufacturing_code = 'ND2602001')
+BEGIN
+    INSERT INTO dbo.manufacturing_projects (
+        manufacturing_code,
+        piece_name,
+        piece_type,
+        design_date,
+        designer_name,
+        status,
+        craftsman_name,
+        metal_plating_json,
+        metal_plating_notes,
+        setting_cost,
+        diamond_cost,
+        gemstone_cost,
+        total_cost,
+        selling_price,
+        completion_date,
+        usage_notes,
+        photos_json,
+        customer_id,
+        sold_at
+    )
+    VALUES (
+        N'ND2602001',
+        N'Lotus Crown Necklace',
+        N'necklace',
+        CAST(DATEADD(DAY, -48, SYSUTCDATETIME()) AS DATE),
+        N'ML Rojanatorn',
+        N'sold',
+        N'Pichai',
+        N'["white_gold","rose_gold"]',
+        N'Dual-toned plating with hand-polished finish.',
+        55000,
+        86000,
+        72000,
+        213000,
+        268000,
+        CAST(DATEADD(DAY, -14, SYSUTCDATETIME()) AS DATE),
+        N'Sold after VIP preview.',
+        N'[]',
+        @customerNicha,
+        DATEADD(DAY, -10, SYSUTCDATETIME())
+    );
+END
+
+IF NOT EXISTS (SELECT 1 FROM dbo.manufacturing_projects WHERE manufacturing_code = 'ND2602002')
+BEGIN
+    INSERT INTO dbo.manufacturing_projects (
+        manufacturing_code,
+        piece_name,
+        piece_type,
+        design_date,
+        designer_name,
+        status,
+        craftsman_name,
+        metal_plating_json,
+        metal_plating_notes,
+        setting_cost,
+        diamond_cost,
+        gemstone_cost,
+        total_cost,
+        selling_price,
+        completion_date,
+        usage_notes,
+        photos_json,
+        customer_id,
+        sold_at
+    )
+    VALUES (
+        N'ND2602002',
+        N'Heritage Emerald Brooch',
+        N'brooch',
+        CAST(DATEADD(DAY, -32, SYSUTCDATETIME()) AS DATE),
+        N'Praewa',
+        N'ready_for_sale',
+        N'Tui',
+        N'["gold"]',
+        N'Classic yellow-gold tone.',
+        42000,
+        51000,
+        46000,
+        139000,
+        184000,
+        CAST(DATEADD(DAY, -4, SYSUTCDATETIME()) AS DATE),
+        N'Ready for in-stock display and certificate generation.',
+        N'[]',
+        NULL,
+        NULL
+    );
+END
+
+IF NOT EXISTS (SELECT 1 FROM dbo.manufacturing_projects WHERE manufacturing_code = 'ND2602003')
+BEGIN
+    INSERT INTO dbo.manufacturing_projects (
+        manufacturing_code,
+        piece_name,
+        piece_type,
+        design_date,
+        designer_name,
+        status,
+        craftsman_name,
+        metal_plating_json,
+        metal_plating_notes,
+        setting_cost,
+        diamond_cost,
+        gemstone_cost,
+        total_cost,
+        selling_price,
+        completion_date,
+        usage_notes,
+        photos_json,
+        customer_id,
+        sold_at
+    )
+    VALUES (
+        N'ND2602003',
+        N'Celestial Drop Earrings',
+        N'earrings',
+        CAST(DATEADD(DAY, -12, SYSUTCDATETIME()) AS DATE),
+        N'Dao',
+        N'stone_setting',
+        N'Ti',
+        N'["white_gold"]',
+        N'Rhodium plating for high contrast.',
+        21000,
+        32000,
+        26000,
+        79000,
+        116000,
+        NULL,
+        N'Pending final setting QC.',
+        N'[]',
+        @customerMichael,
+        NULL
+    );
+END
+GO
+
+DECLARE @project1 INT = (SELECT TOP 1 id FROM dbo.manufacturing_projects WHERE manufacturing_code = 'ND2602001');
+DECLARE @project2 INT = (SELECT TOP 1 id FROM dbo.manufacturing_projects WHERE manufacturing_code = 'ND2602002');
+DECLARE @project3 INT = (SELECT TOP 1 id FROM dbo.manufacturing_projects WHERE manufacturing_code = 'ND2602003');
+
+DECLARE @inventory1 INT = (
+    SELECT TOP 1 id
+    FROM dbo.gem_inventory_items
+    WHERE COALESCE(balance_ct, parsed_weight_ct, 0) > 0
+    ORDER BY COALESCE(parsed_price_per_ct, parsed_price_per_piece, 0) DESC, id
+);
+
+DECLARE @inventory2 INT = (
+    SELECT TOP 1 id
+    FROM dbo.gem_inventory_items
+    WHERE id <> ISNULL(@inventory1, -1)
+      AND COALESCE(balance_ct, parsed_weight_ct, 0) > 0
+    ORDER BY COALESCE(parsed_price_per_ct, parsed_price_per_piece, 0) DESC, id
+);
+
+DECLARE @inventory3 INT = (
+    SELECT TOP 1 id
+    FROM dbo.gem_inventory_items
+    WHERE id NOT IN (ISNULL(@inventory1, -1), ISNULL(@inventory2, -1))
+      AND COALESCE(balance_ct, parsed_weight_ct, 0) > 0
+    ORDER BY COALESCE(parsed_price_per_ct, parsed_price_per_piece, 0) DESC, id
+);
+
+IF @project1 IS NOT NULL AND NOT EXISTS (SELECT 1 FROM dbo.manufacturing_project_gemstones WHERE project_id = @project1)
+BEGIN
+    INSERT INTO dbo.manufacturing_project_gemstones (project_id, inventory_item_id, gemstone_code, gemstone_type, pieces_used, weight_used_ct, line_cost, notes)
+    SELECT @project1, @inventory1, CAST(gemstone_number AS NVARCHAR(64)), gemstone_type, 3, 4.8, 72000, N'Primary center set'
+    FROM dbo.gem_inventory_items WHERE id = @inventory1;
+
+    INSERT INTO dbo.manufacturing_project_gemstones (project_id, inventory_item_id, gemstone_code, gemstone_type, pieces_used, weight_used_ct, line_cost, notes)
+    SELECT @project1, @inventory2, CAST(gemstone_number AS NVARCHAR(64)), gemstone_type, 6, 2.4, 28000, N'Side accent stones'
+    FROM dbo.gem_inventory_items WHERE id = @inventory2;
+END
+
+IF @project2 IS NOT NULL AND NOT EXISTS (SELECT 1 FROM dbo.manufacturing_project_gemstones WHERE project_id = @project2)
+BEGIN
+    INSERT INTO dbo.manufacturing_project_gemstones (project_id, inventory_item_id, gemstone_code, gemstone_type, pieces_used, weight_used_ct, line_cost, notes)
+    SELECT @project2, @inventory2, CAST(gemstone_number AS NVARCHAR(64)), gemstone_type, 2, 1.8, 19000, N'Brooch highlights'
+    FROM dbo.gem_inventory_items WHERE id = @inventory2;
+END
+
+IF @project3 IS NOT NULL AND NOT EXISTS (SELECT 1 FROM dbo.manufacturing_project_gemstones WHERE project_id = @project3)
+BEGIN
+    INSERT INTO dbo.manufacturing_project_gemstones (project_id, inventory_item_id, gemstone_code, gemstone_type, pieces_used, weight_used_ct, line_cost, notes)
+    SELECT @project3, @inventory3, CAST(gemstone_number AS NVARCHAR(64)), gemstone_type, 8, 3.1, 26000, N'Matched pair layout'
+    FROM dbo.gem_inventory_items WHERE id = @inventory3;
+END
+
+IF @project1 IS NOT NULL AND NOT EXISTS (SELECT 1 FROM dbo.manufacturing_activity_log WHERE project_id = @project1)
+BEGIN
+    INSERT INTO dbo.manufacturing_activity_log (project_id, status, activity_at_utc, craftsman_name, notes)
+    VALUES
+        (@project1, N'approved', DATEADD(DAY, -48, SYSUTCDATETIME()), N'Pichai', N'Project approved for production.'),
+        (@project1, N'stone_setting', DATEADD(DAY, -28, SYSUTCDATETIME()), N'Pichai', N'Stone setting completed.'),
+        (@project1, N'sold', DATEADD(DAY, -10, SYSUTCDATETIME()), N'Pichai', N'Sold to VIP client.');
+END
+
+IF @project2 IS NOT NULL AND NOT EXISTS (SELECT 1 FROM dbo.manufacturing_activity_log WHERE project_id = @project2)
+BEGIN
+    INSERT INTO dbo.manufacturing_activity_log (project_id, status, activity_at_utc, craftsman_name, notes)
+    VALUES
+        (@project2, N'approved', DATEADD(DAY, -32, SYSUTCDATETIME()), N'Tui', N'Project kickoff approved.'),
+        (@project2, N'ready_for_sale', DATEADD(DAY, -4, SYSUTCDATETIME()), N'Tui', N'Ready for showroom release.');
+END
+
+IF @project3 IS NOT NULL AND NOT EXISTS (SELECT 1 FROM dbo.manufacturing_activity_log WHERE project_id = @project3)
+BEGIN
+    INSERT INTO dbo.manufacturing_activity_log (project_id, status, activity_at_utc, craftsman_name, notes)
+    VALUES
+        (@project3, N'approved', DATEADD(DAY, -12, SYSUTCDATETIME()), N'Ti', N'Blueprint and casting approved.'),
+        (@project3, N'stone_setting', DATEADD(DAY, -2, SYSUTCDATETIME()), N'Ti', N'Active stone-setting stage.');
+END
+GO


### PR DESCRIPTION
## Summary
- add customer + manufacturing SQL schema (`migrations/003_customer_manufacturing_schema.sql`)
- add seed script for baseline customer/manufacturing demo data (`tools/db/seed_customer_manufacturing.sql`)
- implement backend customer/manufacturing/analytics endpoints and SQL services
- add dashboard modules for Customers, Purchases, Manufacturing, and Analytics tabs
- expand smoke tests to cover new API surfaces

## Data and Environment Work Performed
- applied migrations `001`, `002`, `003` to Azure SQL
- imported workbook data from `ROJANATORN GEMS STOCK 2026.xlsx`
- seeded customer/manufacturing records
- seeded and verified Cosmos test users including admin

## Validation
- `dotnet build backend/backend.csproj --configuration Release`
- `npm --prefix frontend run build`
- `python3 tools/validation/api_smoke.py --base-url http://localhost:7071/api`

Closes #9
