### PR TITLE
Add Static Web App SPA fallback for client routes

### DIFF
--- a/frontend/public/staticwebapp.config.json
+++ b/frontend/public/staticwebapp.config.json
@@ -1,0 +1,9 @@
+{
+  "navigationFallback": {
+    "rewrite": "/index.html",
+    "exclude": [
+      "/assets/*",
+      "/*.{css,js,png,jpg,jpeg,gif,svg,ico,woff,woff2,ttf,map,json,txt}"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- add `frontend/public/staticwebapp.config.json`
- configure `navigationFallback` rewrite to `/index.html` for SPA routes

## Validation
- `npm --prefix frontend run build`
- verified `frontend/dist/staticwebapp.config.json` exists

Closes #13
