### PR TITLE
Convert gemstone inventory to table with incremental loading

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -453,6 +453,21 @@ select {
   background: #fff8ee;
 }
 
+.table-footer {
+  margin-top: 0.7rem;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.6rem;
+  flex-wrap: wrap;
+}
+
+.table-footer p {
+  margin: 0;
+  color: var(--ink-700);
+  font-size: 0.82rem;
+}
+
 .detail-drawer {
   margin-top: 0.2rem;
 }


### PR DESCRIPTION
## Summary
- replace inventory card grid with a table-first layout for easier scanning
- add server-backed incremental loading (`See more`) using page size 50
- preserve existing click-to-open gemstone detail drawer
- add footer metadata showing shown vs total rows

## Validation
- `npm --prefix frontend run build`

Closes #15
