### PR TITLE
Refresh UI to clean white style across all pages

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,36 +1,64 @@
 :root {
-  --ink-900: #191610;
-  --ink-700: #4b4133;
-  --ink-500: #746956;
-  --paper: #f4efe6;
-  --panel: #fffefb;
-  --accent-700: #6a4b2f;
-  --accent-500: #9f774f;
-  --accent-200: #e7dbc9;
-  --danger-600: #b7233b;
+  --ink-900: #111827;
+  --ink-700: #4b5563;
+  --ink-500: #6b7280;
+  --canvas: #f5f6f8;
+  --panel: #ffffff;
+  --panel-soft: #f9fafb;
+  --line: #e5e7eb;
+  --line-strong: #d1d5db;
+  --accent-700: #1d4ed8;
+  --accent-500: #2563eb;
+  --accent-100: #dbeafe;
+  --danger-600: #b91c1c;
+  --elev-1: 0 8px 24px rgba(15, 23, 42, 0.04);
+  --elev-2: 0 20px 38px rgba(15, 23, 42, 0.08);
   color: var(--ink-900);
-  font-family: 'Avenir Next', 'Gill Sans', 'Trebuchet MS', sans-serif;
+  font-family: 'Avenir Next', 'Segoe UI', 'Helvetica Neue', sans-serif;
 }
 
 * {
   box-sizing: border-box;
 }
 
+html,
+body,
+#root {
+  min-height: 100%;
+}
+
 body {
   margin: 0;
   min-width: 320px;
   min-height: 100vh;
-  background:
-    radial-gradient(circle at 20% 0%, #fff8ed 0%, transparent 36%),
-    radial-gradient(circle at 80% 100%, #f1e1ca 0%, transparent 44%),
-    linear-gradient(160deg, #f4efe6 0%, #ebe4d7 60%, #f7f1e8 100%);
+  background: var(--canvas);
   color: var(--ink-900);
+}
+
+a {
+  color: var(--accent-700);
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
 }
 
 button,
 input,
-select {
+select,
+textarea {
   font: inherit;
+  color: inherit;
+}
+
+button:focus-visible,
+input:focus-visible,
+select:focus-visible,
+textarea:focus-visible,
+a:focus-visible {
+  outline: 2px solid var(--accent-500);
+  outline-offset: 2px;
 }
 
 .primary-btn,
@@ -39,17 +67,24 @@ select {
   padding: 0.62rem 1rem;
   border: 1px solid transparent;
   cursor: pointer;
-  transition: transform 0.15s ease, box-shadow 0.15s ease, background-color 0.15s ease;
+  transition: background-color 0.15s ease, border-color 0.15s ease, box-shadow 0.15s ease;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.4rem;
+  text-decoration: none;
+  white-space: nowrap;
 }
 
 .primary-btn {
   color: #fff;
-  background: linear-gradient(135deg, var(--accent-700), var(--accent-500));
-  box-shadow: 0 8px 20px rgba(106, 75, 47, 0.32);
+  background: linear-gradient(180deg, var(--accent-500), var(--accent-700));
+  border-color: #1e40af;
+  box-shadow: 0 10px 20px rgba(37, 99, 235, 0.28);
 }
 
 .primary-btn:hover:not(:disabled) {
-  transform: translateY(-1px);
+  box-shadow: 0 12px 22px rgba(37, 99, 235, 0.35);
 }
 
 .primary-btn:disabled {
@@ -59,27 +94,39 @@ select {
 
 .secondary-btn {
   background: #fff;
-  border-color: #d5c7b2;
+  border-color: var(--line-strong);
   color: var(--ink-900);
 }
 
 .secondary-btn:hover {
-  background: #fef8ee;
+  background: #f8fafc;
+  border-color: #c7ced8;
+  text-decoration: none;
 }
 
 .auth-shell {
   min-height: 100vh;
+  width: min(1320px, 100%);
+  margin: 0 auto;
   display: grid;
-  grid-template-columns: 1fr 420px;
-  gap: 2.4rem;
-  padding: 2.5rem;
+  grid-template-columns: minmax(0, 1fr) 420px;
+  gap: 1.8rem;
+  padding: 2rem clamp(1rem, 4vw, 2.5rem);
   align-items: center;
+}
+
+.auth-intro {
+  background: var(--panel);
+  border: 1px solid var(--line);
+  border-radius: 20px;
+  box-shadow: var(--elev-1);
+  padding: clamp(1.2rem, 2.8vw, 2rem);
 }
 
 .auth-intro h1 {
   margin: 0;
-  font-size: clamp(2rem, 4vw, 3.1rem);
-  letter-spacing: 0.02em;
+  font-size: clamp(2rem, 4vw, 3rem);
+  letter-spacing: 0.01em;
 }
 
 .auth-intro p {
@@ -89,21 +136,22 @@ select {
 }
 
 .auth-intro ul {
-  margin-top: 1.3rem;
+  margin-top: 1.25rem;
+  margin-bottom: 0;
   padding-left: 1.1rem;
   color: var(--ink-700);
 }
 
 .auth-intro li {
-  margin-top: 0.55rem;
+  margin-top: 0.5rem;
 }
 
 .auth-card {
   background: var(--panel);
-  border: 1px solid #dfcfb7;
-  border-radius: 18px;
-  box-shadow: 0 20px 35px rgba(57, 43, 27, 0.15);
-  padding: 1.4rem;
+  border: 1px solid var(--line);
+  border-radius: 20px;
+  box-shadow: var(--elev-2);
+  padding: 1.35rem;
   display: flex;
   flex-direction: column;
   gap: 0.72rem;
@@ -121,13 +169,13 @@ select {
 
 .auth-mode-row {
   display: flex;
-  gap: 0.6rem;
+  gap: 0.55rem;
   margin-top: 0.2rem;
 }
 
 .auth-mode-row button {
   flex: 1;
-  border: 1px solid #ddcfb8;
+  border: 1px solid var(--line-strong);
   border-radius: 9px;
   background: #fff;
   padding: 0.52rem 0.64rem;
@@ -135,21 +183,22 @@ select {
 }
 
 .auth-mode-row button.active {
-  border-color: var(--accent-500);
-  background: #fbf2e2;
+  border-color: #93c5fd;
+  background: #eff6ff;
+  color: #1e3a8a;
   font-weight: 650;
 }
 
 .auth-card label {
-  margin-top: 0.45rem;
+  margin-top: 0.4rem;
   font-weight: 550;
   font-size: 0.9rem;
 }
 
 .auth-card input {
   width: 100%;
-  border-radius: 9px;
-  border: 1px solid #d8cab3;
+  border-radius: 10px;
+  border: 1px solid var(--line-strong);
   padding: 0.68rem 0.74rem;
   background: #fff;
 }
@@ -163,16 +212,17 @@ select {
 .dashboard-shell {
   min-height: 100vh;
   display: grid;
-  grid-template-columns: 250px minmax(0, 1fr);
+  grid-template-columns: 260px minmax(0, 1fr);
+  background: var(--canvas);
 }
 
 .dashboard-sidebar {
-  background: linear-gradient(180deg, #efe6d8, #e8dcc8);
-  border-right: 1px solid #d8cab2;
+  background: #fff;
+  border-right: 1px solid var(--line);
   padding: 1.2rem 1rem;
   display: flex;
   flex-direction: column;
-  gap: 1.25rem;
+  gap: 1.2rem;
 }
 
 .brand-mark {
@@ -197,12 +247,12 @@ select {
   width: 14px;
   height: 14px;
   border-radius: 999px;
-  background: linear-gradient(140deg, #6d4d32, #b48a60);
+  background: linear-gradient(160deg, #3b82f6, #1d4ed8);
 }
 
 .sidebar-nav {
   display: grid;
-  gap: 0.55rem;
+  gap: 0.5rem;
 }
 
 .sidebar-nav button {
@@ -211,23 +261,29 @@ select {
   border: 1px solid transparent;
   border-radius: 10px;
   background: transparent;
-  padding: 0.6rem 0.68rem;
+  padding: 0.58rem 0.68rem;
   cursor: pointer;
   color: var(--ink-900);
 }
 
+.sidebar-nav button:hover {
+  background: #f8fafc;
+  border-color: #e5e7eb;
+}
+
 .sidebar-nav button.active {
-  background: #fff7ea;
-  border-color: #c8b08f;
-  box-shadow: 0 8px 18px rgba(100, 72, 44, 0.14);
+  background: #eff6ff;
+  border-color: #bfdbfe;
+  color: #1e3a8a;
+  font-weight: 600;
 }
 
 .sidebar-user {
   margin-top: auto;
-  border: 1px solid #d3c2aa;
+  border: 1px solid var(--line);
   border-radius: 12px;
-  background: rgba(255, 255, 255, 0.7);
-  padding: 0.7rem;
+  background: var(--panel-soft);
+  padding: 0.68rem;
 }
 
 .sidebar-user p {
@@ -238,15 +294,15 @@ select {
 
 .sidebar-user span {
   display: inline-block;
-  margin-top: 0.36rem;
+  margin-top: 0.34rem;
   font-size: 0.72rem;
   color: var(--ink-700);
 }
 
 .dashboard-main {
-  padding: 1.4rem 1.4rem 2rem;
+  padding: 1.35rem;
   display: grid;
-  gap: 1rem;
+  gap: 0.95rem;
 }
 
 .dashboard-header {
@@ -254,6 +310,11 @@ select {
   justify-content: space-between;
   align-items: flex-start;
   gap: 0.9rem;
+  background: #fff;
+  border: 1px solid var(--line);
+  border-radius: 16px;
+  padding: 0.95rem 1rem;
+  box-shadow: var(--elev-1);
 }
 
 .dashboard-header h2 {
@@ -267,11 +328,11 @@ select {
 
 .error-banner {
   margin: 0;
-  border: 1px solid #e79eab;
+  border: 1px solid #fecaca;
   border-radius: 10px;
   padding: 0.65rem 0.75rem;
-  color: #7b1628;
-  background: #ffeef1;
+  color: #991b1b;
+  background: #fef2f2;
 }
 
 .stats-grid {
@@ -281,10 +342,11 @@ select {
 }
 
 .stats-grid article {
-  background: var(--panel);
-  border: 1px solid #dbcbb2;
+  background: #fff;
+  border: 1px solid var(--line);
   border-radius: 13px;
   padding: 0.82rem;
+  box-shadow: var(--elev-1);
 }
 
 .stats-grid h3 {
@@ -302,10 +364,11 @@ select {
 
 .content-card,
 .detail-drawer {
-  background: var(--panel);
-  border: 1px solid #ddcfb7;
+  background: #fff;
+  border: 1px solid var(--line);
   border-radius: 14px;
   padding: 0.95rem;
+  box-shadow: var(--elev-1);
 }
 
 .card-head {
@@ -334,10 +397,14 @@ select {
 
 .filter-grid input,
 .filter-grid select {
-  border: 1px solid #d7c8b1;
+  border: 1px solid var(--line-strong);
   border-radius: 9px;
   padding: 0.55rem 0.58rem;
   background: #fff;
+}
+
+.filter-grid input::placeholder {
+  color: var(--ink-500);
 }
 
 .panel-placeholder {
@@ -354,15 +421,16 @@ select {
 .inventory-card {
   width: 100%;
   text-align: left;
-  border: 1px solid #deceb6;
+  border: 1px solid var(--line);
   border-radius: 12px;
   padding: 0.72rem;
-  background: linear-gradient(180deg, #fffefb, #fff7ed);
+  background: #fff;
   cursor: pointer;
 }
 
 .inventory-card:hover {
-  border-color: #c6a37b;
+  border-color: #bfdbfe;
+  background: #f8fbff;
 }
 
 .inventory-card h4 {
@@ -404,25 +472,32 @@ select {
   padding: 0.2rem 0.52rem;
   font-size: 0.7rem;
   font-weight: 650;
+  border: 1px solid transparent;
 }
 
 .stock-pill.ok {
-  background: #dff5e6;
-  color: #1f6b36;
+  background: #dcfce7;
+  border-color: #bbf7d0;
+  color: #166534;
 }
 
 .stock-pill.low {
-  background: #fff1cc;
-  color: #8c6600;
+  background: #fef3c7;
+  border-color: #fde68a;
+  color: #92400e;
 }
 
 .stock-pill.out {
-  background: #ffe1e3;
-  color: #872431;
+  background: #fee2e2;
+  border-color: #fecaca;
+  color: #991b1b;
 }
 
 .usage-table-wrap {
   overflow-x: auto;
+  border: 1px solid var(--line);
+  border-radius: 12px;
+  background: #fff;
 }
 
 .usage-table {
@@ -435,13 +510,14 @@ select {
   font-weight: 650;
   font-size: 0.8rem;
   color: var(--ink-700);
-  border-bottom: 1px solid #e7dbc8;
-  padding: 0.52rem 0.45rem;
+  border-bottom: 1px solid var(--line);
+  background: #f8fafc;
+  padding: 0.58rem 0.5rem;
 }
 
 .usage-table td {
-  border-bottom: 1px solid #f0e6d6;
-  padding: 0.52rem 0.45rem;
+  border-bottom: 1px solid #eef2f7;
+  padding: 0.58rem 0.5rem;
   font-size: 0.87rem;
 }
 
@@ -450,7 +526,7 @@ select {
 }
 
 .usage-table tbody tr:hover {
-  background: #fff8ee;
+  background: #f8fbff;
 }
 
 .table-footer {
@@ -514,10 +590,10 @@ select {
 
 .crm-form-grid {
   margin: 0.85rem 0 1rem;
-  padding: 0.75rem;
-  border: 1px solid #e2d4bc;
+  padding: 0.78rem;
+  border: 1px solid var(--line);
   border-radius: 12px;
-  background: #fffbf3;
+  background: var(--panel-soft);
   display: grid;
   gap: 0.55rem;
   grid-template-columns: repeat(2, minmax(0, 1fr));
@@ -533,7 +609,7 @@ select {
 .crm-form-grid input,
 .crm-form-grid select,
 .crm-form-grid textarea {
-  border: 1px solid #d7c8b1;
+  border: 1px solid var(--line-strong);
   border-radius: 8px;
   padding: 0.48rem 0.56rem;
   background: #fff;
@@ -567,7 +643,7 @@ select {
 
 .crm-note-editor textarea {
   width: 100%;
-  border: 1px solid #d7c8b1;
+  border: 1px solid var(--line-strong);
   border-radius: 8px;
   padding: 0.55rem;
   background: #fff;
@@ -579,10 +655,10 @@ select {
 }
 
 .activity-list article {
-  border: 1px solid #ebdfcc;
+  border: 1px solid var(--line);
   border-radius: 10px;
   padding: 0.5rem 0.6rem;
-  background: #fffdf8;
+  background: #fff;
 }
 
 .activity-list p {
@@ -598,10 +674,37 @@ select {
 }
 
 .status-update-row select {
-  border: 1px solid #d7c8b1;
+  border: 1px solid var(--line-strong);
   border-radius: 8px;
   padding: 0.48rem 0.56rem;
   background: #fff;
+}
+
+.not-found-page {
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 1.2rem;
+  background: var(--canvas);
+}
+
+.not-found-card {
+  background: #fff;
+  border: 1px solid var(--line);
+  border-radius: 16px;
+  padding: 1.2rem 1.4rem;
+  box-shadow: var(--elev-1);
+  text-align: center;
+}
+
+.not-found-card h1 {
+  margin: 0;
+  font-size: 2rem;
+}
+
+.not-found-card p {
+  margin: 0.45rem 0 0.85rem;
+  color: var(--ink-700);
 }
 
 @media (max-width: 1080px) {
@@ -617,7 +720,7 @@ select {
 
   .dashboard-sidebar {
     border-right: 0;
-    border-bottom: 1px solid #d8cab2;
+    border-bottom: 1px solid var(--line);
   }
 
   .stats-grid {

--- a/frontend/src/pages/NotFoundPage.tsx
+++ b/frontend/src/pages/NotFoundPage.tsx
@@ -2,11 +2,11 @@ import { Link } from 'react-router-dom'
 
 export function NotFoundPage() {
   return (
-    <div style={{ minHeight: '100vh', display: 'grid', placeItems: 'center' }}>
-      <div>
+    <div className="not-found-page">
+      <div className="not-found-card">
         <h1>404</h1>
         <p>Route not found.</p>
-        <Link to="/dashboard">Go to dashboard</Link>
+        <Link className="secondary-btn" to="/dashboard">Go to dashboard</Link>
       </div>
     </div>
   )


### PR DESCRIPTION
## Summary
- overhaul shared styles in `frontend/src/index.css` for a clean white visual language
- standardize buttons, cards, tables, forms, sidebar, and dashboard shell surfaces
- update not-found page to use styled layout instead of inline styles

## Validation
- `npm --prefix frontend run build`

Closes #17
