### PR TITLE
Fix gemstone/manufacturing detail views and sidebar UX

### DIFF
--- a/backend/Models/InventoryModels.cs
+++ b/backend/Models/InventoryModels.cs
@@ -15,7 +15,7 @@ public sealed class InventorySummaryResponse
     public decimal EstimatedInventoryValue { get; init; }
 }
 
-public sealed class InventoryItemResponse
+public class InventoryItemResponse
 {
     public int Id { get; init; }
     public int? GemstoneNumber { get; init; }
@@ -35,6 +35,42 @@ public sealed class InventoryItemResponse
     public decimal? ParsedPricePerPiece { get; init; }
     public decimal EffectiveBalancePcs { get; init; }
     public decimal EffectiveBalanceCt { get; init; }
+}
+
+public sealed class InventoryUsageActivityResponse
+{
+    public int LineId { get; init; }
+    public int BatchId { get; init; }
+    public DateTime? TransactionDate { get; init; }
+    public string? ProductCode { get; init; }
+    public string ProductCategory { get; init; } = string.Empty;
+    public string? RequesterName { get; init; }
+    public decimal? UsedPcs { get; init; }
+    public decimal? UsedWeightCt { get; init; }
+    public decimal? LineAmount { get; init; }
+    public decimal? BalancePcsAfter { get; init; }
+    public decimal? BalanceCtAfter { get; init; }
+}
+
+public sealed class InventoryManufacturingActivityResponse
+{
+    public int ProjectId { get; init; }
+    public string ManufacturingCode { get; init; } = string.Empty;
+    public string PieceName { get; init; } = string.Empty;
+    public string? PieceType { get; init; }
+    public string Status { get; init; } = string.Empty;
+    public DateTime? ActivityAtUtc { get; init; }
+    public string? CraftsmanName { get; init; }
+    public string? Notes { get; init; }
+    public decimal PiecesUsed { get; init; }
+    public decimal WeightUsedCt { get; init; }
+    public decimal LineCost { get; init; }
+}
+
+public sealed class InventoryItemDetailResponse : InventoryItemResponse
+{
+    public IReadOnlyList<InventoryUsageActivityResponse> UsageActivities { get; init; } = [];
+    public IReadOnlyList<InventoryManufacturingActivityResponse> ManufacturingActivities { get; init; } = [];
 }
 
 public sealed class UsageBatchResponse

--- a/backend/Services/NoopGemInventorySqlService.cs
+++ b/backend/Services/NoopGemInventorySqlService.cs
@@ -16,8 +16,8 @@ public sealed class NoopGemInventorySqlService : IGemInventorySqlService
         CancellationToken cancellationToken = default)
         => Task.FromResult(new PagedResponse<InventoryItemResponse>([], 0, Math.Clamp(limit, 1, 200), Math.Max(offset, 0)));
 
-    public Task<InventoryItemResponse?> GetInventoryItemByIdAsync(int id, CancellationToken cancellationToken = default)
-        => Task.FromResult<InventoryItemResponse?>(null);
+    public Task<InventoryItemDetailResponse?> GetInventoryItemByIdAsync(int id, CancellationToken cancellationToken = default)
+        => Task.FromResult<InventoryItemDetailResponse?>(null);
 
     public Task<PagedResponse<UsageBatchResponse>> GetUsageBatchesAsync(
         string? search,

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -41,6 +41,39 @@ export interface InventoryItem {
   effectiveBalanceCt: number
 }
 
+export interface InventoryUsageActivity {
+  lineId: number
+  batchId: number
+  transactionDate: string | null
+  productCode: string | null
+  productCategory: string
+  requesterName: string | null
+  usedPcs: number | null
+  usedWeightCt: number | null
+  lineAmount: number | null
+  balancePcsAfter: number | null
+  balanceCtAfter: number | null
+}
+
+export interface InventoryManufacturingActivity {
+  projectId: number
+  manufacturingCode: string
+  pieceName: string
+  pieceType: string | null
+  status: string
+  activityAtUtc: string | null
+  craftsmanName: string | null
+  notes: string | null
+  piecesUsed: number
+  weightUsedCt: number
+  lineCost: number
+}
+
+export interface InventoryItemDetail extends InventoryItem {
+  usageActivities: InventoryUsageActivity[]
+  manufacturingActivities: InventoryManufacturingActivity[]
+}
+
 export interface UsageBatch {
   id: number
   productCategory: string

--- a/frontend/src/components/dashboard/ManufacturingPanel.tsx
+++ b/frontend/src/components/dashboard/ManufacturingPanel.tsx
@@ -320,85 +320,107 @@ export function ManufacturingPanel() {
       </section>
 
       {selected ? (
-        <section className="detail-drawer">
-          <div className="drawer-head">
-            <h3>{selected.manufacturingCode} · {selected.pieceName}</h3>
-            <button type="button" className="secondary-btn" onClick={() => setSelected(null)}>Close</button>
-          </div>
-
-          <div className="drawer-grid">
-            <p><strong>Type:</strong> {labelize(selected.pieceType)}</p>
-            <p><strong>Status:</strong> {labelize(selected.status)}</p>
-            <p><strong>Designer:</strong> {selected.designerName ?? '-'}</p>
-            <p><strong>Craftsman:</strong> {selected.craftsmanName ?? '-'}</p>
-            <p><strong>Selling Price:</strong> {formatCurrency(selected.sellingPrice)}</p>
-            <p><strong>Total Cost:</strong> {formatCurrency(selected.totalCost)}</p>
-            <p><strong>Design Date:</strong> {formatDate(selected.designDate)}</p>
-            <p><strong>Completion Date:</strong> {formatDate(selected.completionDate)}</p>
-            <p><strong>Customer:</strong> {selected.customerName ?? '-'}</p>
-            <p><strong>Sold At:</strong> {formatDate(selected.soldAt)}</p>
-          </div>
-
-          <div className="status-update-row">
-            <select value={selectedStatus} onChange={event => setSelectedStatus(event.target.value)}>
-              {STATUS_OPTIONS.map(status => (
-                <option key={status} value={status}>{labelize(status)}</option>
-              ))}
-            </select>
-            <button type="button" className="primary-btn" onClick={() => void handleUpdateStatus()} disabled={isSaving || selectedStatus === selected.status}>
-              {isSaving ? 'Updating...' : 'Update Status'}
-            </button>
-          </div>
-
-          {selected.usageNotes ? (
-            <div className="usage-lines">
-              <h4>Notes</h4>
-              <p>{selected.usageNotes}</p>
+        <div className="detail-modal-backdrop" onClick={() => setSelected(null)}>
+          <section className="detail-modal-panel" onClick={event => event.stopPropagation()}>
+            <div className="drawer-head">
+              <h3>{selected.manufacturingCode} · {selected.pieceName}</h3>
+              <button type="button" className="secondary-btn" onClick={() => setSelected(null)}>Close</button>
             </div>
-          ) : null}
 
-          <div className="usage-lines">
-            <h4>Gemstones</h4>
-            {selected.gemstones.length === 0 ? (
-              <p className="panel-placeholder">No gemstones linked yet.</p>
-            ) : (
-              <div className="activity-list">
-                {selected.gemstones.map(gem => (
-                  <article key={gem.id}>
-                    <p>
-                      <strong>{gem.gemstoneCode ?? `#${gem.inventoryItemId ?? '?'}`}</strong>
-                      {' • '}
-                      {gem.gemstoneType ?? 'Unknown'}
-                    </p>
-                    <p>{gem.weightUsedCt} ct / {gem.piecesUsed} pcs</p>
-                    <p>{formatCurrency(gem.lineCost)}</p>
-                    {gem.notes ? <p>{gem.notes}</p> : null}
-                  </article>
-                ))}
-              </div>
-            )}
-          </div>
+            <div className="drawer-grid">
+              <p><strong>Type:</strong> {labelize(selected.pieceType)}</p>
+              <p><strong>Status:</strong> {labelize(selected.status)}</p>
+              <p><strong>Design Date:</strong> {formatDate(selected.designDate)}</p>
+              <p><strong>Completion Date:</strong> {formatDate(selected.completionDate)}</p>
+              <p><strong>Designer:</strong> {selected.designerName ?? '-'}</p>
+              <p><strong>Craftsman:</strong> {selected.craftsmanName ?? '-'}</p>
+              <p><strong>Metal Plating:</strong> {selected.metalPlating.length > 0 ? selected.metalPlating.map(value => labelize(value)).join(', ') : '-'}</p>
+              <p><strong>Plating Notes:</strong> {selected.metalPlatingNotes ?? '-'}</p>
+              <p><strong>Setting Cost:</strong> {formatCurrency(selected.settingCost)}</p>
+              <p><strong>Diamond Cost:</strong> {formatCurrency(selected.diamondCost)}</p>
+              <p><strong>Gemstone Cost:</strong> {formatCurrency(selected.gemstoneCost)}</p>
+              <p><strong>Selling Price:</strong> {formatCurrency(selected.sellingPrice)}</p>
+              <p><strong>Total Cost:</strong> {formatCurrency(selected.totalCost)}</p>
+              <p><strong>Customer:</strong> {selected.customerName ?? '-'}</p>
+              <p><strong>Sold At:</strong> {formatDate(selected.soldAt)}</p>
+              <p><strong>Created:</strong> {formatDate(selected.createdAtUtc)}</p>
+              <p><strong>Updated:</strong> {formatDate(selected.updatedAtUtc)}</p>
+            </div>
 
-          <div className="usage-lines">
-            <h4>Activity Log</h4>
-            {selected.activityLog.length === 0 ? (
-              <p className="panel-placeholder">No activity entries yet.</p>
-            ) : (
-              <div className="activity-list">
-                {selected.activityLog.map(entry => (
-                  <article key={entry.id}>
-                    <p>
-                      <strong>{labelize(entry.status)}</strong>
-                      {' • '}
-                      {formatDate(entry.activityAtUtc)}
-                    </p>
-                    {entry.notes ? <p>{entry.notes}</p> : null}
-                  </article>
+            <div className="status-update-row">
+              <select value={selectedStatus} onChange={event => setSelectedStatus(event.target.value)}>
+                {STATUS_OPTIONS.map(status => (
+                  <option key={status} value={status}>{labelize(status)}</option>
                 ))}
+              </select>
+              <button type="button" className="primary-btn" onClick={() => void handleUpdateStatus()} disabled={isSaving || selectedStatus === selected.status}>
+                {isSaving ? 'Updating...' : 'Update Status'}
+              </button>
+            </div>
+
+            {selected.usageNotes ? (
+              <div className="usage-lines">
+                <h4>Notes</h4>
+                <p>{selected.usageNotes}</p>
               </div>
-            )}
-          </div>
-        </section>
+            ) : null}
+
+            {selected.photos.length > 0 ? (
+              <div className="usage-lines">
+                <h4>Photos</h4>
+                <div className="activity-list">
+                  {selected.photos.map((photo, index) => (
+                    <article key={`${photo}-${index}`}>
+                      <a href={photo} target="_blank" rel="noreferrer">{photo}</a>
+                    </article>
+                  ))}
+                </div>
+              </div>
+            ) : null}
+
+            <div className="usage-lines">
+              <h4>Gemstones</h4>
+              {selected.gemstones.length === 0 ? (
+                <p className="panel-placeholder">No gemstones linked yet.</p>
+              ) : (
+                <div className="activity-list">
+                  {selected.gemstones.map(gem => (
+                    <article key={gem.id}>
+                      <p>
+                        <strong>{gem.gemstoneCode ?? `#${gem.inventoryItemId ?? '?'}`}</strong>
+                        {' • '}
+                        {gem.gemstoneType ?? 'Unknown'}
+                      </p>
+                      <p>{gem.weightUsedCt} ct / {gem.piecesUsed} pcs</p>
+                      <p>{formatCurrency(gem.lineCost)}</p>
+                      {gem.notes ? <p>{gem.notes}</p> : null}
+                    </article>
+                  ))}
+                </div>
+              )}
+            </div>
+
+            <div className="usage-lines">
+              <h4>Activity Log</h4>
+              {selected.activityLog.length === 0 ? (
+                <p className="panel-placeholder">No activity entries yet.</p>
+              ) : (
+                <div className="activity-list">
+                  {selected.activityLog.map(entry => (
+                    <article key={entry.id}>
+                      <p>
+                        <strong>{labelize(entry.status)}</strong>
+                        {' • '}
+                        {formatDate(entry.activityAtUtc)}
+                      </p>
+                      {entry.notes ? <p>{entry.notes}</p> : null}
+                    </article>
+                  ))}
+                </div>
+              )}
+            </div>
+          </section>
+        </div>
       ) : null}
     </>
   )

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -225,6 +225,13 @@ a:focus-visible {
   gap: 1.2rem;
 }
 
+.sidebar-top-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+
 .brand-mark {
   display: flex;
   align-items: center;
@@ -250,6 +257,19 @@ a:focus-visible {
   background: linear-gradient(160deg, #3b82f6, #1d4ed8);
 }
 
+.sidebar-toggle {
+  border: 1px solid var(--line);
+  background: #fff;
+  border-radius: 10px;
+  width: 32px;
+  height: 32px;
+  cursor: pointer;
+}
+
+.sidebar-toggle:hover {
+  background: #f8fafc;
+}
+
 .sidebar-nav {
   display: grid;
   gap: 0.5rem;
@@ -258,6 +278,9 @@ a:focus-visible {
 .sidebar-nav button {
   width: 100%;
   text-align: left;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
   border: 1px solid transparent;
   border-radius: 10px;
   background: transparent;
@@ -276,6 +299,10 @@ a:focus-visible {
   border-color: #bfdbfe;
   color: #1e3a8a;
   font-weight: 600;
+}
+
+.label-short {
+  display: none;
 }
 
 .sidebar-user {
@@ -299,31 +326,59 @@ a:focus-visible {
   color: var(--ink-700);
 }
 
+.sidebar-signout {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  border: 1px solid #fca5a5;
+  border-radius: 10px;
+  background: #fff1f2;
+  color: #b91c1c;
+  padding: 0.58rem 0.68rem;
+  cursor: pointer;
+  font-weight: 600;
+}
+
+.sidebar-signout:hover {
+  background: #ffe4e6;
+}
+
+.sidebar-collapsed {
+  grid-template-columns: 88px minmax(0, 1fr);
+}
+
+.sidebar-collapsed .brand-mark div,
+.sidebar-collapsed .sidebar-user {
+  display: none;
+}
+
+.sidebar-collapsed .sidebar-nav button,
+.sidebar-collapsed .sidebar-signout {
+  justify-content: center;
+  text-align: center;
+  padding-left: 0.3rem;
+  padding-right: 0.3rem;
+}
+
+.sidebar-collapsed .label-full {
+  display: none;
+}
+
+.sidebar-collapsed .label-short {
+  display: inline;
+}
+
 .dashboard-main {
   padding: 1.35rem;
   display: grid;
   gap: 0.95rem;
 }
 
-.dashboard-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: flex-start;
-  gap: 0.9rem;
-  background: #fff;
-  border: 1px solid var(--line);
-  border-radius: 16px;
-  padding: 0.95rem 1rem;
-  box-shadow: var(--elev-1);
-}
-
-.dashboard-header h2 {
+.page-subtitle {
   margin: 0;
-}
-
-.dashboard-header p {
-  margin: 0.35rem 0 0;
   color: var(--ink-700);
+  font-size: 0.9rem;
 }
 
 .error-banner {
@@ -546,6 +601,27 @@ a:focus-visible {
 
 .detail-drawer {
   margin-top: 0.2rem;
+}
+
+.detail-modal-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(17, 24, 39, 0.38);
+  z-index: 60;
+  display: grid;
+  place-items: center;
+  padding: 1rem;
+}
+
+.detail-modal-panel {
+  width: min(940px, 100%);
+  max-height: 88vh;
+  overflow: auto;
+  background: #fff;
+  border: 1px solid var(--line);
+  border-radius: 16px;
+  box-shadow: 0 26px 46px rgba(15, 23, 42, 0.2);
+  padding: 1rem;
 }
 
 .drawer-head {


### PR DESCRIPTION
Closes #23

## What changed
- Added modal-based detail views for manufacturing and gemstone row clicks.
- Expanded manufacturing detail content to include all key project fields (cost breakdown, plating, metadata, photos, activities).
- Added gemstone activity support (manufacturing + usage) by extending backend inventory detail response.
- Updated API models/client mappings for inventory detail activities.
- Moved sign-out to the left sidebar and added sidebar collapse/expand behavior with compact labels.
- Removed dependency on large top dashboard header/sign-out area by using subtitle-only top content.

## Validation
- `dotnet build backend/backend.csproj` ✅
- `npm --prefix frontend run build` ✅ (build passes; local Node warns 20.16.0 vs Vite recommended 20.19+)
- `API_BASE_URL=https://houseofrojanatorn-g8exadena3btbea7.southeastasia-01.azurewebsites.net/api tools/validation/run_api_smoke.sh` ⚠️ timed out on `PUT /manufacturing/{id}` after passing earlier smoke steps.
