### PR TITLE
Add configurable manufacturing settings, AI note intake, and invite-only users

### DIFF
--- a/backend/Functions/AuthFunctions.cs
+++ b/backend/Functions/AuthFunctions.cs
@@ -1,5 +1,6 @@
 using System.IdentityModel.Tokens.Jwt;
 using System.Net;
+using System.Security.Cryptography;
 using System.Security.Claims;
 using System.Text.Json;
 using backend.Models;
@@ -12,6 +13,11 @@ namespace backend.Functions;
 
 public class AuthFunctions
 {
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true
+    };
+
     private readonly IUserRepository _repository;
     private readonly PasswordHasher<UserRecord> _passwordHasher;
     private readonly IJwtService _jwtService;
@@ -27,10 +33,13 @@ public class AuthFunctions
     public async Task<HttpResponseData> CreateUser(
         [HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = "users")] HttpRequestData req)
     {
-        var createRequest = await JsonSerializer.DeserializeAsync<CreateUserRequest>(req.Body, new JsonSerializerOptions
+        var totalUsers = await _repository.CountAsync(req.FunctionContext.CancellationToken);
+        if (totalUsers > 0)
         {
-            PropertyNameCaseInsensitive = true
-        });
+            return await ForbiddenAsync(req, "Direct user creation is disabled. Use admin invite flow.");
+        }
+
+        var createRequest = await JsonSerializer.DeserializeAsync<CreateUserRequest>(req.Body, JsonOptions);
 
         if (createRequest is null || string.IsNullOrWhiteSpace(createRequest.Email) || string.IsNullOrWhiteSpace(createRequest.Password))
         {
@@ -51,7 +60,9 @@ public class AuthFunctions
         var newUser = new UserRecord
         {
             Email = normalizedEmail,
-            Role = UserRoles.Normalize(createRequest.Role)
+            Role = UserRoles.Normalize(createRequest.Role),
+            CreatedAtUtc = DateTime.UtcNow,
+            ActivatedAtUtc = DateTime.UtcNow
         };
 
         newUser.PasswordHash = _passwordHasher.HashPassword(newUser, createRequest.Password);
@@ -68,10 +79,7 @@ public class AuthFunctions
     public async Task<HttpResponseData> Login(
         [HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = "login")] HttpRequestData req)
     {
-        var loginRequest = await JsonSerializer.DeserializeAsync<LoginRequest>(req.Body, new JsonSerializerOptions
-        {
-            PropertyNameCaseInsensitive = true
-        });
+        var loginRequest = await JsonSerializer.DeserializeAsync<LoginRequest>(req.Body, JsonOptions);
 
         if (loginRequest is null)
         {
@@ -88,6 +96,13 @@ public class AuthFunctions
             return unauthorized;
         }
 
+        if (string.IsNullOrWhiteSpace(user.PasswordHash))
+        {
+            var unauthorized = req.CreateResponse(HttpStatusCode.Unauthorized);
+            await unauthorized.WriteStringAsync("Invite has not been accepted yet.");
+            return unauthorized;
+        }
+
         var verification = _passwordHasher.VerifyHashedPassword(user, user.PasswordHash, loginRequest.Password);
         if (verification == PasswordVerificationResult.Failed)
         {
@@ -95,6 +110,183 @@ public class AuthFunctions
             await unauthorized.WriteStringAsync("Invalid credentials.");
             return unauthorized;
         }
+
+        user.LastLoginAtUtc = DateTime.UtcNow;
+        await _repository.UpsertAsync(user);
+
+        var auth = _jwtService.GenerateToken(user);
+        var response = req.CreateResponse(HttpStatusCode.OK);
+        await response.WriteAsJsonAsync(auth);
+        return response;
+    }
+
+    [Function("GetUsers")]
+    public async Task<HttpResponseData> GetUsers(
+        [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "users")] HttpRequestData req,
+        FunctionContext executionContext)
+    {
+        var principal = GetPrincipal(executionContext);
+        if (!IsAdmin(principal))
+        {
+            return await ForbiddenAsync(req, "Admin role required.");
+        }
+
+        var query = System.Web.HttpUtility.ParseQueryString(req.Url.Query);
+        var limit = ParseInt(query["limit"], 100);
+        var continuationToken = query["continuationToken"];
+
+        var users = await _repository.ListAsync(limit, continuationToken, req.FunctionContext.CancellationToken);
+        var response = req.CreateResponse(HttpStatusCode.OK);
+        await response.WriteAsJsonAsync(users);
+        return response;
+    }
+
+    [Function("DeleteUser")]
+    public async Task<HttpResponseData> DeleteUser(
+        [HttpTrigger(AuthorizationLevel.Anonymous, "delete", Route = "users/{id}")] HttpRequestData req,
+        FunctionContext executionContext,
+        string id)
+    {
+        var principal = GetPrincipal(executionContext);
+        if (!IsAdmin(principal))
+        {
+            return await ForbiddenAsync(req, "Admin role required.");
+        }
+
+        var currentUserId = principal?.FindFirstValue(ClaimTypes.NameIdentifier) ?? principal?.FindFirstValue(JwtRegisteredClaimNames.Sub);
+        if (!string.IsNullOrWhiteSpace(currentUserId) && string.Equals(currentUserId, id, StringComparison.Ordinal))
+        {
+            return await BadRequestAsync(req, "You cannot delete your own account.");
+        }
+
+        var user = await _repository.GetByIdAsync(id, req.FunctionContext.CancellationToken);
+        if (user is null)
+        {
+            return await NotFoundAsync(req, "User not found.");
+        }
+
+        if (string.Equals(UserRoles.Normalize(user.Role), UserRoles.Admin, StringComparison.Ordinal))
+        {
+            var listed = await _repository.ListAsync(200, null, req.FunctionContext.CancellationToken);
+            var adminCount = listed.Items.Count(item => string.Equals(item.Role, UserRoles.Admin, StringComparison.Ordinal));
+            if (adminCount <= 1)
+            {
+                return await BadRequestAsync(req, "At least one admin account is required.");
+            }
+        }
+
+        var deleted = await _repository.DeleteAsync(id, req.FunctionContext.CancellationToken);
+        if (!deleted)
+        {
+            return await NotFoundAsync(req, "User not found.");
+        }
+
+        var response = req.CreateResponse(HttpStatusCode.OK);
+        await response.WriteAsJsonAsync(new { success = true });
+        return response;
+    }
+
+    [Function("InviteUser")]
+    public async Task<HttpResponseData> InviteUser(
+        [HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = "users/invite")] HttpRequestData req,
+        FunctionContext executionContext)
+    {
+        var principal = GetPrincipal(executionContext);
+        if (!IsAdmin(principal))
+        {
+            return await ForbiddenAsync(req, "Admin role required.");
+        }
+
+        var inviteRequest = await JsonSerializer.DeserializeAsync<InviteUserRequest>(req.Body, JsonOptions);
+        if (inviteRequest is null || string.IsNullOrWhiteSpace(inviteRequest.Email))
+        {
+            return await BadRequestAsync(req, "Email is required.");
+        }
+
+        var normalizedEmail = inviteRequest.Email.Trim().ToLowerInvariant();
+        var role = UserRoles.Normalize(inviteRequest.Role);
+        var expiresInDays = Math.Clamp(inviteRequest.ExpiresInDays ?? 7, 1, 30);
+        var expiresAtUtc = DateTime.UtcNow.AddDays(expiresInDays);
+        var token = GenerateInviteToken();
+
+        var existing = await _repository.GetByEmailAsync(normalizedEmail, req.FunctionContext.CancellationToken);
+        if (existing is not null && !string.IsNullOrWhiteSpace(existing.PasswordHash))
+        {
+            return await ConflictAsync(req, "Active user already exists.");
+        }
+
+        if (existing is null)
+        {
+            var invited = new UserRecord
+            {
+                Email = normalizedEmail,
+                Role = role,
+                PasswordHash = string.Empty,
+                InviteToken = token,
+                InviteExpiresAtUtc = expiresAtUtc,
+                CreatedAtUtc = DateTime.UtcNow
+            };
+
+            await _repository.CreateAsync(invited, req.FunctionContext.CancellationToken);
+        }
+        else
+        {
+            existing.Role = role;
+            existing.InviteToken = token;
+            existing.InviteExpiresAtUtc = expiresAtUtc;
+            existing.PasswordHash = string.Empty;
+            existing.ActivatedAtUtc = null;
+            await _repository.UpsertAsync(existing, req.FunctionContext.CancellationToken);
+        }
+
+        var response = req.CreateResponse(HttpStatusCode.Created);
+        await response.WriteAsJsonAsync(new InviteResponse(normalizedEmail, role, token, expiresAtUtc));
+        return response;
+    }
+
+    [Function("GetInviteDetails")]
+    public async Task<HttpResponseData> GetInviteDetails(
+        [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "users/invite/{token}")] HttpRequestData req,
+        string token)
+    {
+        var user = await _repository.GetByInviteTokenAsync(token, req.FunctionContext.CancellationToken);
+        if (user is null || user.InviteExpiresAtUtc is null || user.InviteExpiresAtUtc <= DateTime.UtcNow)
+        {
+            return await NotFoundAsync(req, "Invite is invalid or has expired.");
+        }
+
+        var response = req.CreateResponse(HttpStatusCode.OK);
+        await response.WriteAsJsonAsync(new InviteDetailsResponse(user.Email, UserRoles.Normalize(user.Role), user.InviteExpiresAtUtc.Value));
+        return response;
+    }
+
+    [Function("AcceptInvite")]
+    public async Task<HttpResponseData> AcceptInvite(
+        [HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = "users/invite/accept")] HttpRequestData req)
+    {
+        var acceptRequest = await JsonSerializer.DeserializeAsync<AcceptInviteRequest>(req.Body, JsonOptions);
+        if (acceptRequest is null || string.IsNullOrWhiteSpace(acceptRequest.Token) || string.IsNullOrWhiteSpace(acceptRequest.Password))
+        {
+            return await BadRequestAsync(req, "Token and password are required.");
+        }
+
+        var user = await _repository.GetByInviteTokenAsync(acceptRequest.Token.Trim(), req.FunctionContext.CancellationToken);
+        if (user is null)
+        {
+            return await NotFoundAsync(req, "Invite not found.");
+        }
+
+        if (user.InviteExpiresAtUtc is null || user.InviteExpiresAtUtc <= DateTime.UtcNow)
+        {
+            return await BadRequestAsync(req, "Invite has expired.");
+        }
+
+        user.PasswordHash = _passwordHasher.HashPassword(user, acceptRequest.Password);
+        user.InviteToken = null;
+        user.InviteExpiresAtUtc = null;
+        user.ActivatedAtUtc = DateTime.UtcNow;
+        user.LastLoginAtUtc = DateTime.UtcNow;
+        await _repository.UpsertAsync(user, req.FunctionContext.CancellationToken);
 
         var auth = _jwtService.GenerateToken(user);
         var response = req.CreateResponse(HttpStatusCode.OK);
@@ -123,6 +315,64 @@ public class AuthFunctions
     {
         var response = req.CreateResponse(HttpStatusCode.OK);
         await response.WriteAsJsonAsync(new LookupsResponse(new[] { UserRoles.Member, UserRoles.Admin }));
+        return response;
+    }
+
+    private static ClaimsPrincipal? GetPrincipal(FunctionContext context)
+    {
+        return context.Items.TryGetValue("UserPrincipal", out var value) ? value as ClaimsPrincipal : null;
+    }
+
+    private static bool IsAdmin(ClaimsPrincipal? principal)
+    {
+        var role = principal?.FindFirstValue(ClaimTypes.Role);
+        return string.Equals(UserRoles.Normalize(role), UserRoles.Admin, StringComparison.Ordinal);
+    }
+
+    private static string GenerateInviteToken()
+    {
+        var bytes = RandomNumberGenerator.GetBytes(24);
+        return Convert.ToBase64String(bytes)
+            .TrimEnd('=')
+            .Replace('+', '-')
+            .Replace('/', '_');
+    }
+
+    private static int ParseInt(string? value, int fallback)
+    {
+        if (int.TryParse(value, out var parsed))
+        {
+            return parsed;
+        }
+
+        return fallback;
+    }
+
+    private static async Task<HttpResponseData> BadRequestAsync(HttpRequestData req, string message)
+    {
+        var response = req.CreateResponse(HttpStatusCode.BadRequest);
+        await response.WriteAsJsonAsync(new { error = message });
+        return response;
+    }
+
+    private static async Task<HttpResponseData> ConflictAsync(HttpRequestData req, string message)
+    {
+        var response = req.CreateResponse(HttpStatusCode.Conflict);
+        await response.WriteAsJsonAsync(new { error = message });
+        return response;
+    }
+
+    private static async Task<HttpResponseData> ForbiddenAsync(HttpRequestData req, string message)
+    {
+        var response = req.CreateResponse(HttpStatusCode.Forbidden);
+        await response.WriteAsJsonAsync(new { error = message });
+        return response;
+    }
+
+    private static async Task<HttpResponseData> NotFoundAsync(HttpRequestData req, string message)
+    {
+        var response = req.CreateResponse(HttpStatusCode.NotFound);
+        await response.WriteAsJsonAsync(new { error = message });
         return response;
     }
 }

--- a/backend/Functions/CustomerManufacturingFunctions.cs
+++ b/backend/Functions/CustomerManufacturingFunctions.cs
@@ -1,5 +1,7 @@
 using System.Net;
+using System.Security.Claims;
 using System.Text.Json;
+using System.Text.RegularExpressions;
 using backend.Models;
 using backend.Services;
 using Microsoft.Azure.Functions.Worker;
@@ -295,6 +297,69 @@ public sealed class CustomerManufacturingFunctions
         return response;
     }
 
+    [Function("GetManufacturingSettings")]
+    public async Task<HttpResponseData> GetManufacturingSettings(
+        [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "manufacturing/settings")] HttpRequestData req)
+    {
+        var settings = await _service.GetManufacturingSettingsAsync(req.FunctionContext.CancellationToken);
+        var response = req.CreateResponse(HttpStatusCode.OK);
+        await response.WriteAsJsonAsync(settings);
+        return response;
+    }
+
+    [Function("UpdateManufacturingSettings")]
+    public async Task<HttpResponseData> UpdateManufacturingSettings(
+        [HttpTrigger(AuthorizationLevel.Anonymous, "put", Route = "manufacturing/settings")] HttpRequestData req,
+        FunctionContext executionContext)
+    {
+        var principal = GetPrincipal(executionContext);
+        if (!IsAdmin(principal))
+        {
+            return await ForbiddenAsync(req, "Admin role required.");
+        }
+
+        var body = await DeserializeBodyAsync<ManufacturingSettingsUpdateRequest>(req);
+        if (body is null)
+        {
+            return await BadRequestAsync(req, "Invalid settings payload.");
+        }
+
+        try
+        {
+            var saved = await _service.SaveManufacturingSettingsAsync(body, req.FunctionContext.CancellationToken);
+            var response = req.CreateResponse(HttpStatusCode.OK);
+            await response.WriteAsJsonAsync(saved);
+            return response;
+        }
+        catch (ArgumentException ex)
+        {
+            return await BadRequestAsync(req, ex.Message);
+        }
+    }
+
+    [Function("ParseManufacturingNote")]
+    public async Task<HttpResponseData> ParseManufacturingNote(
+        [HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = "manufacturing/ai/parse-note")] HttpRequestData req)
+    {
+        var body = await DeserializeBodyAsync<ManufacturingNoteParseRequest>(req);
+        if (body is null || string.IsNullOrWhiteSpace(body.NoteText))
+        {
+            return await BadRequestAsync(req, "Note text is required.");
+        }
+
+        var settings = await _service.GetManufacturingSettingsAsync(req.FunctionContext.CancellationToken);
+        var defaultStatus = settings.Steps
+            .Where(step => step.IsActive)
+            .OrderBy(step => step.SortOrder)
+            .Select(step => step.StepKey)
+            .FirstOrDefault() ?? ManufacturingStatuses.Approved;
+
+        var parsed = ParseDraftFromNote(body.NoteText, defaultStatus);
+        var response = req.CreateResponse(HttpStatusCode.OK);
+        await response.WriteAsJsonAsync(parsed);
+        return response;
+    }
+
     private static async Task<T?> DeserializeBodyAsync<T>(HttpRequestData req)
     {
         try
@@ -321,6 +386,13 @@ public sealed class CustomerManufacturingFunctions
         return response;
     }
 
+    private static async Task<HttpResponseData> ForbiddenAsync(HttpRequestData req, string message)
+    {
+        var response = req.CreateResponse(HttpStatusCode.Forbidden);
+        await response.WriteAsJsonAsync(new { error = message });
+        return response;
+    }
+
     private static int ParseInt(string? value, int fallback)
     {
         if (int.TryParse(value, out var parsed))
@@ -329,5 +401,163 @@ public sealed class CustomerManufacturingFunctions
         }
 
         return fallback;
+    }
+
+    private static ClaimsPrincipal? GetPrincipal(FunctionContext context)
+    {
+        return context.Items.TryGetValue("UserPrincipal", out var value) ? value as ClaimsPrincipal : null;
+    }
+
+    private static bool IsAdmin(ClaimsPrincipal? principal)
+    {
+        var role = principal?.FindFirstValue(ClaimTypes.Role);
+        return string.Equals(UserRoles.Normalize(role), UserRoles.Admin, StringComparison.Ordinal);
+    }
+
+    private static ManufacturingNoteParseResponse ParseDraftFromNote(string noteText, string defaultStatus)
+    {
+        var normalized = noteText.Trim();
+        var lines = normalized
+            .Split(['\r', '\n'], StringSplitOptions.RemoveEmptyEntries)
+            .Select(line => line.Trim())
+            .Where(line => line.Length > 0)
+            .ToList();
+
+        var manufacturingCode = Regex.Match(normalized, @"\b[A-Z]{1,4}\d{5,}\b").Value;
+        if (string.IsNullOrWhiteSpace(manufacturingCode))
+        {
+            manufacturingCode = Regex.Match(normalized, @"\b[A-Z]{2}\d{4,}\b").Value;
+        }
+
+        var designerName = FindLabeledValue(lines, ["designer", "design by", "designer name"]);
+        var craftsmanName = FindLabeledValue(lines, ["craftsman", "maker", "craft by"]);
+        var pieceName = FindLabeledValue(lines, ["piece", "item", "product"]);
+        var pieceType = DetectPieceType(normalized);
+
+        if (string.IsNullOrWhiteSpace(pieceName))
+        {
+            pieceName = pieceType is null ? "New Piece From Note" : $"{pieceType} from note";
+        }
+
+        decimal? sellingPrice = TryExtractMoney(normalized, ["selling", "sale", "sell"]);
+        decimal? totalCost = TryExtractMoney(normalized, ["total cost", "cost"]);
+
+        var gemstones = ParseGemstoneLines(lines);
+
+        return new ManufacturingNoteParseResponse
+        {
+            ManufacturingCode = string.IsNullOrWhiteSpace(manufacturingCode) ? null : manufacturingCode,
+            PieceName = pieceName,
+            PieceType = pieceType,
+            Status = ManufacturingStatuses.NormalizeOrDefault(defaultStatus),
+            DesignerName = designerName,
+            CraftsmanName = craftsmanName,
+            UsageNotes = normalized,
+            TotalCost = totalCost,
+            SellingPrice = sellingPrice,
+            Gemstones = gemstones
+        };
+    }
+
+    private static string? FindLabeledValue(IEnumerable<string> lines, IEnumerable<string> labels)
+    {
+        foreach (var line in lines)
+        {
+            foreach (var label in labels)
+            {
+                var pattern = $"^{Regex.Escape(label)}\\s*[:\\-]\\s*(.+)$";
+                var match = Regex.Match(line, pattern, RegexOptions.IgnoreCase);
+                if (match.Success)
+                {
+                    return match.Groups[1].Value.Trim();
+                }
+            }
+        }
+
+        return null;
+    }
+
+    private static string? DetectPieceType(string text)
+    {
+        var mapping = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["earring"] = "earrings",
+            ["earrings"] = "earrings",
+            ["bracelet"] = "bracelet",
+            ["choker"] = "choker",
+            ["necklace"] = "necklace",
+            ["brooch"] = "brooch",
+            ["ring"] = "ring",
+            ["pendant"] = "pendant"
+        };
+
+        foreach (var pair in mapping)
+        {
+            if (Regex.IsMatch(text, $"\\b{Regex.Escape(pair.Key)}\\b", RegexOptions.IgnoreCase))
+            {
+                return pair.Value;
+            }
+        }
+
+        return null;
+    }
+
+    private static decimal? TryExtractMoney(string text, IEnumerable<string> labels)
+    {
+        foreach (var label in labels)
+        {
+            var match = Regex.Match(text, $"{Regex.Escape(label)}\\s*[:\\-]?\\s*([\\d,]+(?:\\.\\d+)?)", RegexOptions.IgnoreCase);
+            if (match.Success && decimal.TryParse(match.Groups[1].Value.Replace(",", ""), out var value))
+            {
+                return value;
+            }
+        }
+
+        return null;
+    }
+
+    private static IReadOnlyList<ManufacturingGemstoneUpsertRequest> ParseGemstoneLines(IEnumerable<string> lines)
+    {
+        var results = new List<ManufacturingGemstoneUpsertRequest>();
+        var regex = new Regex(
+            @"^(?<code>[A-Z0-9\-#]{2,})?(?:\s+)?(?<type>[A-Za-z][A-Za-z0-9\s\-]{1,40})?(?:\s+)?(?:(?<pcs>\d+(?:\.\d+)?)\s*pcs?)?(?:\s+)?(?:(?<ct>\d+(?:\.\d+)?)\s*ct)?(?:\s+)?(?:(?<cost>\d+(?:,\d{3})*(?:\.\d+)?)\s*(?:thb|baht)?)?$",
+            RegexOptions.IgnoreCase);
+
+        foreach (var line in lines)
+        {
+            if (line.Length < 3)
+            {
+                continue;
+            }
+
+            var match = regex.Match(line);
+            if (!match.Success)
+            {
+                continue;
+            }
+
+            var code = match.Groups["code"].Value.Trim();
+            var type = match.Groups["type"].Value.Trim();
+
+            if (string.IsNullOrWhiteSpace(code) && string.IsNullOrWhiteSpace(type))
+            {
+                continue;
+            }
+
+            _ = decimal.TryParse(match.Groups["pcs"].Value, out var pcs);
+            _ = decimal.TryParse(match.Groups["ct"].Value, out var ct);
+            _ = decimal.TryParse(match.Groups["cost"].Value.Replace(",", ""), out var cost);
+
+            results.Add(new ManufacturingGemstoneUpsertRequest
+            {
+                GemstoneCode = string.IsNullOrWhiteSpace(code) ? null : code,
+                GemstoneType = string.IsNullOrWhiteSpace(type) ? null : type,
+                PiecesUsed = pcs > 0 ? pcs : null,
+                WeightUsedCt = ct > 0 ? ct : null,
+                LineCost = cost > 0 ? cost : null
+            });
+        }
+
+        return results;
     }
 }

--- a/backend/Middleware/JwtValidationMiddleware.cs
+++ b/backend/Middleware/JwtValidationMiddleware.cs
@@ -12,6 +12,8 @@ public class JwtValidationMiddleware : IFunctionsWorkerMiddleware
     [
         "CreateUser",
         "Login",
+        "GetInviteDetails",
+        "AcceptInvite",
         "CorsPreflight",
         "GetHealth"
     ];

--- a/backend/Models/AuthModels.cs
+++ b/backend/Models/AuthModels.cs
@@ -17,11 +17,25 @@ public record UpdatePasswordRequest(
 
 public record AuthResponse(string Token, DateTime ExpiresAtUtc, string Role);
 
+public record InviteUserRequest(
+    [property: Required, EmailAddress] string Email,
+    string? Role = null,
+    int? ExpiresInDays = null);
+
+public record AcceptInviteRequest(
+    [property: Required] string Token,
+    [property: Required, MinLength(8)] string Password);
+
 public sealed class UserSummary
 {
     public string id { get; set; } = string.Empty;
     public string Email { get; set; } = string.Empty;
     public string Role { get; set; } = UserRoles.Member;
+    public string Status { get; set; } = "active";
+    public DateTime CreatedAtUtc { get; set; }
+    public DateTime? ActivatedAtUtc { get; set; }
+    public DateTime? LastLoginAtUtc { get; set; }
+    public DateTime? InviteExpiresAtUtc { get; set; }
 }
 
 public sealed class UserListResponse
@@ -29,6 +43,9 @@ public sealed class UserListResponse
     public required IReadOnlyList<UserSummary> Items { get; init; }
     public string? ContinuationToken { get; init; }
 }
+
+public sealed record InviteResponse(string Email, string Role, string Token, DateTime ExpiresAtUtc);
+public sealed record InviteDetailsResponse(string Email, string Role, DateTime ExpiresAtUtc);
 
 public sealed record MeProfileResponse(string UserId, string Email, string Role);
 

--- a/backend/Models/CustomerManufacturingModels.cs
+++ b/backend/Models/CustomerManufacturingModels.cs
@@ -13,7 +13,7 @@ public static class ManufacturingStatuses
     public const string ReadyForSale = "ready_for_sale";
     public const string Sold = "sold";
 
-    public static readonly IReadOnlySet<string> Allowed = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+    public static readonly IReadOnlyList<string> Defaults = new[]
     {
         Approved,
         SentToCraftsman,
@@ -34,8 +34,13 @@ public static class ManufacturingStatuses
             return fallback;
         }
 
-        var normalized = value.Trim().ToLowerInvariant();
-        return Allowed.Contains(normalized) ? normalized : fallback;
+        var normalized = value
+            .Trim()
+            .ToLowerInvariant()
+            .Replace('-', '_')
+            .Replace(' ', '_');
+
+        return string.IsNullOrWhiteSpace(normalized) ? fallback : normalized;
     }
 }
 
@@ -155,6 +160,7 @@ public sealed class ManufacturingProjectSummaryResponse
     public DateTime CreatedAtUtc { get; init; }
     public DateTime UpdatedAtUtc { get; init; }
     public int GemstoneCount { get; init; }
+    public IReadOnlyDictionary<string, string?> CustomFields { get; init; } = new Dictionary<string, string?>();
 }
 
 public sealed class ManufacturingProjectDetailResponse
@@ -184,6 +190,7 @@ public sealed class ManufacturingProjectDetailResponse
     public DateTime UpdatedAtUtc { get; init; }
     public IReadOnlyList<ManufacturingGemstoneResponse> Gemstones { get; init; } = [];
     public IReadOnlyList<ManufacturingActivityLogResponse> ActivityLog { get; init; } = [];
+    public IReadOnlyDictionary<string, string?> CustomFields { get; init; } = new Dictionary<string, string?>();
 }
 
 public sealed class ManufacturingGemstoneUpsertRequest
@@ -220,6 +227,82 @@ public sealed class ManufacturingProjectUpsertRequest
     public DateTime? SoldAt { get; init; }
     public IReadOnlyList<ManufacturingGemstoneUpsertRequest>? Gemstones { get; init; }
     public string? ActivityNote { get; init; }
+    public IReadOnlyDictionary<string, string?>? CustomFields { get; init; }
+}
+
+public sealed class ManufacturingProcessStepResponse
+{
+    public string StepKey { get; init; } = string.Empty;
+    public string Label { get; init; } = string.Empty;
+    public int SortOrder { get; init; }
+    public bool RequirePhoto { get; init; }
+    public bool RequireComment { get; init; }
+    public bool IsActive { get; init; }
+}
+
+public sealed class ManufacturingCustomFieldResponse
+{
+    public string FieldKey { get; init; } = string.Empty;
+    public string Label { get; init; } = string.Empty;
+    public string FieldType { get; init; } = "text";
+    public int SortOrder { get; init; }
+    public bool IsRequired { get; init; }
+    public bool IsActive { get; init; }
+    public bool IsSystem { get; init; }
+    public IReadOnlyList<string> Options { get; init; } = [];
+}
+
+public sealed class ManufacturingSettingsResponse
+{
+    public IReadOnlyList<ManufacturingProcessStepResponse> Steps { get; init; } = [];
+    public IReadOnlyList<ManufacturingCustomFieldResponse> Fields { get; init; } = [];
+}
+
+public sealed class ManufacturingProcessStepUpsertRequest
+{
+    public string? StepKey { get; init; }
+    public string? Label { get; init; }
+    public int? SortOrder { get; init; }
+    public bool RequirePhoto { get; init; }
+    public bool RequireComment { get; init; }
+    public bool IsActive { get; init; } = true;
+}
+
+public sealed class ManufacturingCustomFieldUpsertRequest
+{
+    public string? FieldKey { get; init; }
+    public string? Label { get; init; }
+    public string? FieldType { get; init; }
+    public int? SortOrder { get; init; }
+    public bool IsRequired { get; init; }
+    public bool IsActive { get; init; } = true;
+    public IReadOnlyList<string>? Options { get; init; }
+}
+
+public sealed class ManufacturingSettingsUpdateRequest
+{
+    public IReadOnlyList<ManufacturingProcessStepUpsertRequest>? Steps { get; init; }
+    public IReadOnlyList<ManufacturingCustomFieldUpsertRequest>? Fields { get; init; }
+}
+
+public sealed class ManufacturingNoteParseRequest
+{
+    public string? NoteText { get; init; }
+}
+
+public sealed class ManufacturingNoteParseResponse
+{
+    public string? ManufacturingCode { get; init; }
+    public string? PieceName { get; init; }
+    public string? PieceType { get; init; }
+    public string Status { get; init; } = ManufacturingStatuses.Approved;
+    public string? DesignerName { get; init; }
+    public string? CraftsmanName { get; init; }
+    public string? UsageNotes { get; init; }
+    public decimal? TotalCost { get; init; }
+    public decimal? SellingPrice { get; init; }
+    public IReadOnlyDictionary<string, string?> CustomFields { get; init; } = new Dictionary<string, string?>();
+    public IReadOnlyList<ManufacturingGemstoneUpsertRequest> Gemstones { get; init; } = [];
 }
 
 public sealed class AnalyticsCurrentMonthResponse

--- a/backend/Models/UserRecord.cs
+++ b/backend/Models/UserRecord.cs
@@ -6,4 +6,9 @@ public class UserRecord
     public string Email { get; set; } = string.Empty;
     public string PasswordHash { get; set; } = string.Empty;
     public string Role { get; set; } = UserRoles.Member;
+    public string? InviteToken { get; set; }
+    public DateTime? InviteExpiresAtUtc { get; set; }
+    public DateTime CreatedAtUtc { get; set; } = DateTime.UtcNow;
+    public DateTime? ActivatedAtUtc { get; set; }
+    public DateTime? LastLoginAtUtc { get; set; }
 }

--- a/backend/Services/InMemoryUserRepository.cs
+++ b/backend/Services/InMemoryUserRepository.cs
@@ -41,10 +41,48 @@ public sealed class InMemoryUserRepository : IUserRepository
         return Task.FromResult<UserRecord?>(null);
     }
 
+    public Task<UserRecord?> GetByInviteTokenAsync(string token, CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(token))
+        {
+            return Task.FromResult<UserRecord?>(null);
+        }
+
+        var match = _byId.Values.FirstOrDefault(user =>
+            !string.IsNullOrWhiteSpace(user.InviteToken) &&
+            string.Equals(user.InviteToken, token.Trim(), StringComparison.Ordinal));
+
+        if (match is not null)
+        {
+            match.Role = UserRoles.Normalize(match.Role);
+        }
+
+        return Task.FromResult<UserRecord?>(match);
+    }
+
     public Task CreateAsync(UserRecord user, CancellationToken cancellationToken = default)
     {
         user.Email = user.Email.Trim().ToLowerInvariant();
         user.Role = UserRoles.Normalize(user.Role);
+        if (user.CreatedAtUtc == default)
+        {
+            user.CreatedAtUtc = DateTime.UtcNow;
+        }
+
+        _byId[user.id] = user;
+        _idByEmail[user.Email] = user.id;
+        return Task.CompletedTask;
+    }
+
+    public Task UpsertAsync(UserRecord user, CancellationToken cancellationToken = default)
+    {
+        user.Email = user.Email.Trim().ToLowerInvariant();
+        user.Role = UserRoles.Normalize(user.Role);
+        if (user.CreatedAtUtc == default)
+        {
+            user.CreatedAtUtc = DateTime.UtcNow;
+        }
+
         _byId[user.id] = user;
         _idByEmail[user.Email] = user.id;
         return Task.CompletedTask;
@@ -59,15 +97,45 @@ public sealed class InMemoryUserRepository : IUserRepository
 
         user.PasswordHash = newPasswordHash;
         user.Role = UserRoles.Normalize(user.Role);
+        user.InviteToken = null;
+        user.InviteExpiresAtUtc = null;
+        user.ActivatedAtUtc ??= DateTime.UtcNow;
         return Task.CompletedTask;
     }
 
+    public Task<bool> DeleteAsync(string userId, CancellationToken cancellationToken = default)
+    {
+        if (!_byId.TryRemove(userId, out var existing))
+        {
+            return Task.FromResult(false);
+        }
+
+        _idByEmail.TryRemove(existing.Email, out _);
+        return Task.FromResult(true);
+    }
+
+    public Task<int> CountAsync(CancellationToken cancellationToken = default)
+        => Task.FromResult(_byId.Count);
+
     public Task<UserListResponse> ListAsync(int limit, string? continuationToken, CancellationToken cancellationToken = default)
     {
+        var now = DateTime.UtcNow;
         var items = _byId.Values
             .OrderBy(user => user.Email, StringComparer.OrdinalIgnoreCase)
             .Take(Math.Clamp(limit, 1, 200))
-            .Select(user => new UserSummary { id = user.id, Email = user.Email, Role = UserRoles.Normalize(user.Role) })
+            .Select(user => new UserSummary
+            {
+                id = user.id,
+                Email = user.Email,
+                Role = UserRoles.Normalize(user.Role),
+                Status = string.IsNullOrWhiteSpace(user.PasswordHash) && (user.InviteExpiresAtUtc is null || user.InviteExpiresAtUtc > now)
+                    ? "invited"
+                    : "active",
+                CreatedAtUtc = user.CreatedAtUtc,
+                ActivatedAtUtc = user.ActivatedAtUtc,
+                LastLoginAtUtc = user.LastLoginAtUtc,
+                InviteExpiresAtUtc = user.InviteExpiresAtUtc
+            })
             .ToList();
 
         return Task.FromResult(new UserListResponse

--- a/backend/Services/NoopCustomerManufacturingSqlService.cs
+++ b/backend/Services/NoopCustomerManufacturingSqlService.cs
@@ -51,6 +51,46 @@ public sealed class NoopCustomerManufacturingSqlService : ICustomerManufacturing
     public Task<bool> DeleteManufacturingProjectAsync(int projectId, CancellationToken cancellationToken = default)
         => Task.FromResult(false);
 
+    public Task<ManufacturingSettingsResponse> GetManufacturingSettingsAsync(CancellationToken cancellationToken = default)
+        => Task.FromResult(new ManufacturingSettingsResponse
+        {
+            Steps = ManufacturingStatuses.Defaults
+                .Select((step, index) => new ManufacturingProcessStepResponse
+                {
+                    StepKey = step,
+                    Label = step.Replace('_', ' '),
+                    SortOrder = index + 1,
+                    IsActive = true
+                })
+                .ToList(),
+            Fields =
+            [
+                new ManufacturingCustomFieldResponse
+                {
+                    FieldKey = "designerName",
+                    Label = "Designer",
+                    FieldType = "text",
+                    SortOrder = 1,
+                    IsActive = true,
+                    IsSystem = true
+                },
+                new ManufacturingCustomFieldResponse
+                {
+                    FieldKey = "craftsmanName",
+                    Label = "Craftsman",
+                    FieldType = "text",
+                    SortOrder = 2,
+                    IsActive = true,
+                    IsSystem = true
+                }
+            ]
+        });
+
+    public Task<ManufacturingSettingsResponse> SaveManufacturingSettingsAsync(
+        ManufacturingSettingsUpdateRequest request,
+        CancellationToken cancellationToken = default)
+        => GetManufacturingSettingsAsync(cancellationToken);
+
     public Task<AnalyticsOverviewResponse> GetAnalyticsAsync(CancellationToken cancellationToken = default)
         => Task.FromResult(new AnalyticsOverviewResponse
         {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2,6 +2,7 @@ import { Navigate, Route, Routes } from 'react-router-dom'
 import { SessionProvider } from './app/SessionContext'
 import { useSession } from './app/useSession'
 import { DashboardPage } from './pages/DashboardPage'
+import { AcceptInvitePage } from './pages/AcceptInvitePage'
 import { LoginPage } from './pages/LoginPage'
 import { NotFoundPage } from './pages/NotFoundPage'
 
@@ -31,6 +32,7 @@ function PublicRoutes() {
   return (
     <Routes>
       <Route path="/" element={<LoginPage />} />
+      <Route path="/accept-invite" element={<AcceptInvitePage />} />
       <Route path="*" element={<Navigate replace to="/" />} />
     </Routes>
   )

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -6,6 +6,35 @@ export interface AuthResponse {
   role: AppRole
 }
 
+export interface UserSummary {
+  id: string
+  email: string
+  role: AppRole
+  status: 'active' | 'invited'
+  createdAtUtc: string
+  activatedAtUtc: string | null
+  lastLoginAtUtc: string | null
+  inviteExpiresAtUtc: string | null
+}
+
+export interface UserListResponse {
+  items: UserSummary[]
+  continuationToken: string | null
+}
+
+export interface InviteResponse {
+  email: string
+  role: AppRole
+  token: string
+  expiresAtUtc: string
+}
+
+export interface InviteDetails {
+  email: string
+  role: AppRole
+  expiresAtUtc: string
+}
+
 export interface MeProfile {
   userId: string
   email: string
@@ -195,6 +224,7 @@ export interface ManufacturingProjectSummary {
   createdAtUtc: string
   updatedAtUtc: string
   gemstoneCount: number
+  customFields: Record<string, string | null>
 }
 
 export interface ManufacturingProjectDetail {
@@ -223,6 +253,7 @@ export interface ManufacturingProjectDetail {
   updatedAtUtc: string
   gemstones: ManufacturingGemstone[]
   activityLog: ManufacturingActivityLog[]
+  customFields: Record<string, string | null>
 }
 
 export interface ManufacturingGemstoneUpsertRequest {
@@ -257,6 +288,70 @@ export interface ManufacturingProjectUpsertRequest {
   soldAt?: string | null
   gemstones?: ManufacturingGemstoneUpsertRequest[] | null
   activityNote?: string | null
+  customFields?: Record<string, string | null> | null
+}
+
+export interface ManufacturingProcessStep {
+  stepKey: string
+  label: string
+  sortOrder: number
+  requirePhoto: boolean
+  requireComment: boolean
+  isActive: boolean
+}
+
+export interface ManufacturingCustomField {
+  fieldKey: string
+  label: string
+  fieldType: 'text' | 'textarea' | 'number' | 'date' | 'select'
+  sortOrder: number
+  isRequired: boolean
+  isActive: boolean
+  isSystem: boolean
+  options: string[]
+}
+
+export interface ManufacturingSettings {
+  steps: ManufacturingProcessStep[]
+  fields: ManufacturingCustomField[]
+}
+
+export interface ManufacturingProcessStepUpsertRequest {
+  stepKey?: string | null
+  label?: string | null
+  sortOrder?: number | null
+  requirePhoto?: boolean
+  requireComment?: boolean
+  isActive?: boolean
+}
+
+export interface ManufacturingCustomFieldUpsertRequest {
+  fieldKey?: string | null
+  label?: string | null
+  fieldType?: string | null
+  sortOrder?: number | null
+  isRequired?: boolean
+  isActive?: boolean
+  options?: string[] | null
+}
+
+export interface ManufacturingSettingsUpdateRequest {
+  steps?: ManufacturingProcessStepUpsertRequest[] | null
+  fields?: ManufacturingCustomFieldUpsertRequest[] | null
+}
+
+export interface ManufacturingNoteParseResponse {
+  manufacturingCode: string | null
+  pieceName: string | null
+  pieceType: string | null
+  status: string
+  designerName: string | null
+  craftsmanName: string | null
+  usageNotes: string | null
+  totalCost: number | null
+  sellingPrice: number | null
+  customFields: Record<string, string | null>
+  gemstones: ManufacturingGemstoneUpsertRequest[]
 }
 
 export interface AnalyticsCurrentMonth {

--- a/frontend/src/components/dashboard/SettingsPanel.tsx
+++ b/frontend/src/components/dashboard/SettingsPanel.tsx
@@ -1,0 +1,330 @@
+import { useEffect, useState } from 'react'
+import { getManufacturingSettings, updateManufacturingSettings } from '../../api/client'
+import type { ManufacturingCustomField, ManufacturingProcessStep } from '../../api/types'
+import { useSession } from '../../app/useSession'
+
+function slugify(value: string): string {
+  return value
+    .trim()
+    .replace(/[-\s]+/g, '_')
+    .replace(/[^A-Za-z0-9_]/g, '')
+}
+
+const FIELD_TYPES: ManufacturingCustomField['fieldType'][] = ['text', 'textarea', 'number', 'date', 'select']
+
+export function SettingsPanel() {
+  const { role } = useSession()
+  const [steps, setSteps] = useState<ManufacturingProcessStep[]>([])
+  const [fields, setFields] = useState<ManufacturingCustomField[]>([])
+  const [isLoading, setIsLoading] = useState(true)
+  const [isSaving, setIsSaving] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [success, setSuccess] = useState<string | null>(null)
+
+  const isAdmin = role === 'admin'
+
+  async function loadSettings() {
+    setIsLoading(true)
+    setError(null)
+
+    try {
+      const settings = await getManufacturingSettings()
+      setSteps(settings.steps)
+      setFields(settings.fields)
+    } catch {
+      setError('Unable to load manufacturing settings.')
+    } finally {
+      setIsLoading(false)
+    }
+  }
+
+  useEffect(() => {
+    void loadSettings()
+  }, [])
+
+  function addStep() {
+    setSteps(current => [
+      ...current,
+      {
+        stepKey: '',
+        label: '',
+        sortOrder: current.length + 1,
+        requirePhoto: false,
+        requireComment: false,
+        isActive: true
+      }
+    ])
+  }
+
+  function removeStep(index: number) {
+    setSteps(current => current.filter((_, currentIndex) => currentIndex !== index))
+  }
+
+  function addField() {
+    setFields(current => [
+      ...current,
+      {
+        fieldKey: '',
+        label: '',
+        fieldType: 'text',
+        sortOrder: current.length + 1,
+        isRequired: false,
+        isActive: true,
+        isSystem: false,
+        options: []
+      }
+    ])
+  }
+
+  function removeField(index: number) {
+    setFields(current => current.filter((_, currentIndex) => currentIndex !== index))
+  }
+
+  async function saveSettings() {
+    setIsSaving(true)
+    setError(null)
+    setSuccess(null)
+
+    try {
+      const payload = {
+        steps: steps.map((step, index) => ({
+          stepKey: slugify(step.stepKey || step.label),
+          label: step.label.trim() || step.stepKey,
+          sortOrder: index + 1,
+          requirePhoto: step.requirePhoto,
+          requireComment: step.requireComment,
+          isActive: step.isActive
+        })),
+        fields: fields.map((field, index) => ({
+          fieldKey: field.fieldKey.trim() || slugify(field.label),
+          label: field.label.trim() || field.fieldKey,
+          fieldType: field.fieldType,
+          sortOrder: index + 1,
+          isRequired: field.isRequired,
+          isActive: field.isActive,
+          options: field.fieldType === 'select' ? field.options : []
+        }))
+      }
+
+      const updated = await updateManufacturingSettings(payload)
+      setSteps(updated.steps)
+      setFields(updated.fields)
+      setSuccess('Settings saved.')
+    } catch {
+      setError('Unable to save settings.')
+    } finally {
+      setIsSaving(false)
+    }
+  }
+
+  if (!isAdmin) {
+    return (
+      <section className="content-card">
+        <h3>Settings</h3>
+        <p className="panel-placeholder">Only admin users can edit production pipeline settings.</p>
+      </section>
+    )
+  }
+
+  if (isLoading) {
+    return (
+      <section className="content-card">
+        <h3>Settings</h3>
+        <p className="panel-placeholder">Loading settings...</p>
+      </section>
+    )
+  }
+
+  return (
+    <section className="content-card">
+      <div className="card-head">
+        <div>
+          <h3>Production Settings</h3>
+          <p>Configure workflow steps and dynamic manufacturing fields.</p>
+        </div>
+        <button type="button" className="primary-btn" onClick={() => void saveSettings()} disabled={isSaving}>
+          {isSaving ? 'Saving...' : 'Save Settings'}
+        </button>
+      </div>
+
+      {error ? <p className="error-banner">{error}</p> : null}
+      {success ? <p className="panel-placeholder">{success}</p> : null}
+
+      <div className="usage-lines">
+        <div className="card-head">
+          <h4>Production Steps</h4>
+          <button type="button" className="secondary-btn" onClick={addStep}>Add Step</button>
+        </div>
+        <div className="usage-table-wrap">
+          <table className="usage-table">
+            <thead>
+              <tr>
+                <th>Step Key</th>
+                <th>Label</th>
+                <th>Require Photo</th>
+                <th>Require Comment</th>
+                <th>Active</th>
+                <th>Action</th>
+              </tr>
+            </thead>
+            <tbody>
+              {steps.map((step, index) => (
+                <tr key={`${step.stepKey || 'new'}-${index}`}>
+                  <td>
+                    <input
+                      value={step.stepKey}
+                      onChange={event => {
+                        const value = event.target.value
+                        setSteps(current => current.map((item, itemIndex) => itemIndex === index ? { ...item, stepKey: value } : item))
+                      }}
+                    />
+                  </td>
+                  <td>
+                    <input
+                      value={step.label}
+                      onChange={event => {
+                        const value = event.target.value
+                        setSteps(current => current.map((item, itemIndex) => itemIndex === index ? { ...item, label: value } : item))
+                      }}
+                    />
+                  </td>
+                  <td>
+                    <input
+                      type="checkbox"
+                      checked={step.requirePhoto}
+                      onChange={event => {
+                        const checked = event.target.checked
+                        setSteps(current => current.map((item, itemIndex) => itemIndex === index ? { ...item, requirePhoto: checked } : item))
+                      }}
+                    />
+                  </td>
+                  <td>
+                    <input
+                      type="checkbox"
+                      checked={step.requireComment}
+                      onChange={event => {
+                        const checked = event.target.checked
+                        setSteps(current => current.map((item, itemIndex) => itemIndex === index ? { ...item, requireComment: checked } : item))
+                      }}
+                    />
+                  </td>
+                  <td>
+                    <input
+                      type="checkbox"
+                      checked={step.isActive}
+                      onChange={event => {
+                        const checked = event.target.checked
+                        setSteps(current => current.map((item, itemIndex) => itemIndex === index ? { ...item, isActive: checked } : item))
+                      }}
+                    />
+                  </td>
+                  <td>
+                    <button type="button" className="secondary-btn" onClick={() => removeStep(index)}>Remove</button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      <div className="usage-lines">
+        <div className="card-head">
+          <h4>Manufacturing Fields</h4>
+          <button type="button" className="secondary-btn" onClick={addField}>Add Field</button>
+        </div>
+        <div className="usage-table-wrap">
+          <table className="usage-table">
+            <thead>
+              <tr>
+                <th>Key</th>
+                <th>Label</th>
+                <th>Type</th>
+                <th>Required</th>
+                <th>Active</th>
+                <th>Options (select)</th>
+                <th>Action</th>
+              </tr>
+            </thead>
+            <tbody>
+              {fields.map((field, index) => (
+                <tr key={`${field.fieldKey || 'field'}-${index}`}>
+                  <td>
+                    <input
+                      value={field.fieldKey}
+                      onChange={event => {
+                        const value = event.target.value
+                        setFields(current => current.map((item, itemIndex) => itemIndex === index ? { ...item, fieldKey: value } : item))
+                      }}
+                    />
+                  </td>
+                  <td>
+                    <input
+                      value={field.label}
+                      onChange={event => {
+                        const value = event.target.value
+                        setFields(current => current.map((item, itemIndex) => itemIndex === index ? { ...item, label: value } : item))
+                      }}
+                    />
+                  </td>
+                  <td>
+                    <select
+                      value={field.fieldType}
+                      onChange={event => {
+                        const value = event.target.value as ManufacturingCustomField['fieldType']
+                        setFields(current => current.map((item, itemIndex) => itemIndex === index ? { ...item, fieldType: value } : item))
+                      }}
+                    >
+                      {FIELD_TYPES.map(type => (
+                        <option key={type} value={type}>{type}</option>
+                      ))}
+                    </select>
+                  </td>
+                  <td>
+                    <input
+                      type="checkbox"
+                      checked={field.isRequired}
+                      onChange={event => {
+                        const checked = event.target.checked
+                        setFields(current => current.map((item, itemIndex) => itemIndex === index ? { ...item, isRequired: checked } : item))
+                      }}
+                    />
+                  </td>
+                  <td>
+                    <input
+                      type="checkbox"
+                      checked={field.isActive}
+                      onChange={event => {
+                        const checked = event.target.checked
+                        setFields(current => current.map((item, itemIndex) => itemIndex === index ? { ...item, isActive: checked } : item))
+                      }}
+                    />
+                  </td>
+                  <td>
+                    <input
+                      value={field.options.join(', ')}
+                      placeholder="A, B, C"
+                      onChange={event => {
+                        const value = event.target.value
+                        setFields(current => current.map((item, itemIndex) => itemIndex === index ? {
+                          ...item,
+                          options: value
+                            .split(',')
+                            .map(option => option.trim())
+                            .filter(option => option.length > 0)
+                        } : item))
+                      }}
+                    />
+                  </td>
+                  <td>
+                    <button type="button" className="secondary-btn" onClick={() => removeField(index)}>Remove</button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/frontend/src/components/dashboard/UsersPanel.tsx
+++ b/frontend/src/components/dashboard/UsersPanel.tsx
@@ -1,0 +1,198 @@
+import { useEffect, useMemo, useState } from 'react'
+import { deleteUser, inviteUser, listUsers } from '../../api/client'
+import type { UserSummary } from '../../api/types'
+import { useSession } from '../../app/useSession'
+
+function formatDate(raw: string | null | undefined): string {
+  if (!raw) {
+    return '-'
+  }
+
+  const parsed = new Date(raw)
+  if (Number.isNaN(parsed.getTime())) {
+    return raw
+  }
+
+  return parsed.toLocaleString('en-GB', {
+    day: '2-digit',
+    month: 'short',
+    year: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit'
+  })
+}
+
+export function UsersPanel() {
+  const { role, email } = useSession()
+  const [users, setUsers] = useState<UserSummary[]>([])
+  const [isLoading, setIsLoading] = useState(true)
+  const [isSaving, setIsSaving] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const [inviteEmail, setInviteEmail] = useState('')
+  const [inviteRole, setInviteRole] = useState<'admin' | 'member'>('member')
+  const [inviteDays, setInviteDays] = useState('7')
+  const [latestInviteToken, setLatestInviteToken] = useState<string | null>(null)
+
+  const isAdmin = role === 'admin'
+
+  const inviteLink = useMemo(() => {
+    if (!latestInviteToken) {
+      return null
+    }
+
+    return `${window.location.origin}/accept-invite?token=${encodeURIComponent(latestInviteToken)}`
+  }, [latestInviteToken])
+
+  async function loadUsers() {
+    setIsLoading(true)
+    setError(null)
+
+    try {
+      const result = await listUsers(200)
+      setUsers(result.items)
+    } catch {
+      setError('Unable to load users.')
+    } finally {
+      setIsLoading(false)
+    }
+  }
+
+  useEffect(() => {
+    void loadUsers()
+  }, [])
+
+  async function handleInvite() {
+    if (!inviteEmail.trim()) {
+      setError('Invite email is required.')
+      return
+    }
+
+    setIsSaving(true)
+    setError(null)
+
+    try {
+      const invite = await inviteUser(inviteEmail.trim().toLowerCase(), inviteRole, Number(inviteDays) || 7)
+      setLatestInviteToken(invite.token)
+      setInviteEmail('')
+      await loadUsers()
+    } catch {
+      setError('Unable to create invite.')
+    } finally {
+      setIsSaving(false)
+    }
+  }
+
+  async function handleDelete(userId: string) {
+    if (!window.confirm('Delete this user?')) {
+      return
+    }
+
+    setIsSaving(true)
+    setError(null)
+
+    try {
+      await deleteUser(userId)
+      await loadUsers()
+    } catch {
+      setError('Unable to delete user.')
+    } finally {
+      setIsSaving(false)
+    }
+  }
+
+  if (!isAdmin) {
+    return (
+      <section className="content-card">
+        <h3>Users</h3>
+        <p className="panel-placeholder">Only admin users can manage invited and active accounts.</p>
+      </section>
+    )
+  }
+
+  return (
+    <section className="content-card">
+      <div className="card-head">
+        <div>
+          <h3>Users</h3>
+          <p>{users.length.toLocaleString()} active or invited users</p>
+        </div>
+      </div>
+
+      {error ? <p className="error-banner">{error}</p> : null}
+
+      <div className="crm-form-grid">
+        <label>
+          Invite Email
+          <input value={inviteEmail} onChange={event => setInviteEmail(event.target.value)} placeholder="user@houseofrojanatorn.local" />
+        </label>
+        <label>
+          Role
+          <select value={inviteRole} onChange={event => setInviteRole(event.target.value === 'admin' ? 'admin' : 'member')}>
+            <option value="member">Member</option>
+            <option value="admin">Admin</option>
+          </select>
+        </label>
+        <label>
+          Expires (days)
+          <input type="number" min={1} max={30} value={inviteDays} onChange={event => setInviteDays(event.target.value)} />
+        </label>
+        <div className="crm-form-actions">
+          <button type="button" className="primary-btn" onClick={() => void handleInvite()} disabled={isSaving}>
+            {isSaving ? 'Saving...' : 'Create Invite'}
+          </button>
+        </div>
+      </div>
+
+      {inviteLink ? (
+        <div className="usage-lines">
+          <h4>Latest Invite Link</h4>
+          <p className="panel-placeholder">Share this link with the invited user to set their password:</p>
+          <p><a href={inviteLink}>{inviteLink}</a></p>
+        </div>
+      ) : null}
+
+      {isLoading ? (
+        <p className="panel-placeholder">Loading users...</p>
+      ) : (
+        <div className="usage-table-wrap">
+          <table className="usage-table">
+            <thead>
+              <tr>
+                <th>Email</th>
+                <th>Role</th>
+                <th>Status</th>
+                <th>Last Login</th>
+                <th>Invite Expires</th>
+                <th>Action</th>
+              </tr>
+            </thead>
+            <tbody>
+              {users.map(user => {
+                const canDelete = user.email.toLowerCase() !== email.toLowerCase() && user.email.toLowerCase() !== 'admin@houseofrojanatorn.local'
+                return (
+                  <tr key={user.id}>
+                    <td>{user.email}</td>
+                    <td>{user.role}</td>
+                    <td>{user.status}</td>
+                    <td>{formatDate(user.lastLoginAtUtc)}</td>
+                    <td>{formatDate(user.inviteExpiresAtUtc)}</td>
+                    <td>
+                      {canDelete ? (
+                        <button type="button" className="secondary-btn" onClick={() => void handleDelete(user.id)} disabled={isSaving}>
+                          Delete
+                        </button>
+                      ) : (
+                        '-'
+                      )}
+                    </td>
+                  </tr>
+                )
+              })}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </section>
+  )
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -426,6 +426,10 @@ a:focus-visible {
   box-shadow: var(--elev-1);
 }
 
+.content-card-full {
+  min-height: calc(100vh - 170px);
+}
+
 .card-head {
   display: flex;
   justify-content: space-between;

--- a/frontend/src/pages/AcceptInvitePage.tsx
+++ b/frontend/src/pages/AcceptInvitePage.tsx
@@ -1,0 +1,124 @@
+import { useEffect, useMemo, useState } from 'react'
+import { useNavigate, useSearchParams } from 'react-router-dom'
+import { acceptInvite, getInviteDetails } from '../api/client'
+import { useSession } from '../app/useSession'
+
+export function AcceptInvitePage() {
+  const navigate = useNavigate()
+  const [params] = useSearchParams()
+  const { signIn } = useSession()
+
+  const token = useMemo(() => params.get('token')?.trim() ?? '', [params])
+
+  const [email, setEmail] = useState('')
+  const [role, setRole] = useState('member')
+  const [password, setPassword] = useState('')
+  const [confirmPassword, setConfirmPassword] = useState('')
+  const [loading, setLoading] = useState(true)
+  const [submitting, setSubmitting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (!token) {
+      setError('Invite token is missing.')
+      setLoading(false)
+      return
+    }
+
+    setLoading(true)
+    setError(null)
+
+    void getInviteDetails(token)
+      .then(details => {
+        setEmail(details.email)
+        setRole(details.role)
+      })
+      .catch(() => {
+        setError('Invite link is invalid or expired.')
+      })
+      .finally(() => {
+        setLoading(false)
+      })
+  }, [token])
+
+  async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault()
+
+    if (!token) {
+      setError('Invite token is missing.')
+      return
+    }
+
+    if (password.length < 8) {
+      setError('Password must contain at least 8 characters.')
+      return
+    }
+
+    if (password !== confirmPassword) {
+      setError('Passwords do not match.')
+      return
+    }
+
+    setSubmitting(true)
+    setError(null)
+
+    try {
+      await acceptInvite(token, password)
+      await signIn(email, password)
+      navigate('/dashboard', { replace: true })
+    } catch {
+      setError('Unable to complete invite setup.')
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <div className="auth-shell">
+      <div className="auth-intro">
+        <h1>Set Up Your Account</h1>
+        <p>Use your invite link to create a password and access the operations workspace.</p>
+      </div>
+
+      <form className="auth-card" onSubmit={handleSubmit}>
+        <h2>Accept Invite</h2>
+        {loading ? (
+          <p>Checking invite...</p>
+        ) : error ? (
+          <p className="auth-error">{error}</p>
+        ) : (
+          <>
+            <p>
+              <strong>{email}</strong>
+              {' '}
+              ({role})
+            </p>
+            <label htmlFor="password-input">Password</label>
+            <input
+              id="password-input"
+              type="password"
+              value={password}
+              onChange={event => setPassword(event.target.value)}
+              minLength={8}
+              required
+            />
+
+            <label htmlFor="confirm-password-input">Confirm Password</label>
+            <input
+              id="confirm-password-input"
+              type="password"
+              value={confirmPassword}
+              onChange={event => setConfirmPassword(event.target.value)}
+              minLength={8}
+              required
+            />
+
+            <button type="submit" className="primary-btn" disabled={submitting}>
+              {submitting ? 'Saving...' : 'Set Password and Sign In'}
+            </button>
+          </>
+        )}
+      </form>
+    </div>
+  )
+}

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -6,8 +6,10 @@ import { AnalyticsPanel } from '../components/dashboard/AnalyticsPanel'
 import { CustomersPanel } from '../components/dashboard/CustomersPanel'
 import { ManufacturingPanel } from '../components/dashboard/ManufacturingPanel'
 import { PurchasesPanel } from '../components/dashboard/PurchasesPanel'
+import { SettingsPanel } from '../components/dashboard/SettingsPanel'
+import { UsersPanel } from '../components/dashboard/UsersPanel'
 
-type DashboardTab = 'customers' | 'purchases' | 'inventory' | 'manufacturing' | 'usage' | 'analytics'
+type DashboardTab = 'customers' | 'purchases' | 'inventory' | 'manufacturing' | 'usage' | 'analytics' | 'users' | 'settings'
 const INVENTORY_PAGE_SIZE = 50
 
 function formatCurrency(value: number | null | undefined): string {
@@ -216,6 +218,10 @@ export function DashboardPage() {
       ? 'Customer profiles and relationship notes linked to purchases.'
       : activeTab === 'manufacturing'
         ? 'Production workflow records aligned with the reference prototype.'
+        : activeTab === 'users'
+          ? 'Invite, activate, and manage platform users and roles.'
+          : activeTab === 'settings'
+            ? 'Configure production steps and dynamic manufacturing form fields.'
         : activeTab === 'purchases'
           ? 'Sold records derived from manufacturing projects with status = sold.'
           : activeTab === 'analytics'
@@ -272,6 +278,14 @@ export function DashboardPage() {
             <span className="label-full">Analytics</span>
             <span className="label-short">AN</span>
           </button>
+          <button type="button" className={activeTab === 'users' ? 'active' : ''} onClick={() => setActiveTab('users')}>
+            <span className="label-full">Users</span>
+            <span className="label-short">US</span>
+          </button>
+          <button type="button" className={activeTab === 'settings' ? 'active' : ''} onClick={() => setActiveTab('settings')}>
+            <span className="label-full">Settings</span>
+            <span className="label-short">SE</span>
+          </button>
         </nav>
 
         <section className="sidebar-user">
@@ -319,6 +333,10 @@ export function DashboardPage() {
           <PurchasesPanel />
         ) : activeTab === 'analytics' ? (
           <AnalyticsPanel />
+        ) : activeTab === 'users' ? (
+          <UsersPanel />
+        ) : activeTab === 'settings' ? (
+          <SettingsPanel />
         ) : activeTab === 'inventory' ? (
           <section className="content-card">
             <div className="card-head">

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -1,10 +1,7 @@
 import { useState } from 'react'
-import { useNavigate } from 'react-router-dom'
-import { createUser } from '../api/client'
+import { Link, useNavigate } from 'react-router-dom'
 import { useSession } from '../app/useSession'
 import { HttpError } from '../lib/http'
-
-type AuthMode = 'login' | 'create'
 
 function toUiError(error: unknown): string {
   if (error instanceof HttpError) {
@@ -12,12 +9,8 @@ function toUiError(error: unknown): string {
       return 'Invalid credentials. Please check your email and password.'
     }
 
-    if (error.status === 409) {
-      return 'User already exists. Switch to Sign In.'
-    }
-
     if (error.status === 400) {
-      return 'Invalid request. Ensure email is valid and password has at least 8 characters.'
+      return 'Invalid request. Ensure email and password are both provided.'
     }
   }
 
@@ -31,7 +24,6 @@ function toUiError(error: unknown): string {
 export function LoginPage() {
   const [email, setEmail] = useState('')
   const [password, setPassword] = useState('')
-  const [mode, setMode] = useState<AuthMode>('login')
   const [submitting, setSubmitting] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const navigate = useNavigate()
@@ -39,19 +31,12 @@ export function LoginPage() {
 
   async function onSubmit(event: React.FormEvent<HTMLFormElement>) {
     event.preventDefault()
-    if (!email.trim()) {
-      return
-    }
 
     setSubmitting(true)
     setError(null)
 
     try {
-      if (mode === 'create') {
-        await createUser(email.trim().toLowerCase(), password)
-      }
-
-      await signIn(email, password)
+      await signIn(email.trim().toLowerCase(), password)
       navigate('/dashboard')
     } catch (caughtError) {
       setError(toUiError(caughtError))
@@ -68,22 +53,13 @@ export function LoginPage() {
         <ul>
           <li>Real 2026 workbook stock mapped into Azure SQL</li>
           <li>Inventory and usage traceability by product code</li>
-          <li>Secure role-backed login via Cosmos + JWT</li>
+          <li>Role-based access with invite and password setup flow</li>
         </ul>
       </div>
 
       <form className="auth-card" onSubmit={onSubmit}>
-        <h2>Access Portal</h2>
-        <p>Sign in to continue or create a new internal test user.</p>
-
-        <div className="auth-mode-row">
-          <button type="button" className={mode === 'login' ? 'active' : ''} onClick={() => setMode('login')}>
-            Sign In
-          </button>
-          <button type="button" className={mode === 'create' ? 'active' : ''} onClick={() => setMode('create')}>
-            Create User
-          </button>
-        </div>
+        <h2>Sign In</h2>
+        <p>Use your invited account credentials to access the platform.</p>
 
         <label htmlFor="email-input">
           Email
@@ -105,7 +81,7 @@ export function LoginPage() {
           type="password"
           value={password}
           onChange={(event) => setPassword(event.target.value)}
-          placeholder="minimum 8 characters"
+          placeholder="your password"
           minLength={8}
           required
         />
@@ -113,8 +89,14 @@ export function LoginPage() {
         {error ? <p className="auth-error">{error}</p> : null}
 
         <button type="submit" disabled={submitting} className="primary-btn">
-          {submitting ? 'Please wait...' : mode === 'create' ? 'Create User and Sign In' : 'Sign In'}
+          {submitting ? 'Please wait...' : 'Sign In'}
         </button>
+
+        <p>
+          Need to set your password from an invite?
+          {' '}
+          <Link to="/accept-invite">Open invite setup</Link>
+        </p>
       </form>
     </div>
   )

--- a/migrations/004_manufacturing_settings.sql
+++ b/migrations/004_manufacturing_settings.sql
@@ -1,0 +1,104 @@
+-- Dynamic manufacturing settings for pipeline steps and custom project fields.
+
+IF EXISTS (
+    SELECT 1
+    FROM sys.check_constraints
+    WHERE name = 'CK_manufacturing_projects_status'
+      AND parent_object_id = OBJECT_ID('dbo.manufacturing_projects')
+)
+BEGIN
+    ALTER TABLE dbo.manufacturing_projects
+    DROP CONSTRAINT CK_manufacturing_projects_status;
+END
+GO
+
+IF COL_LENGTH('dbo.manufacturing_projects', 'custom_fields_json') IS NULL
+BEGIN
+    ALTER TABLE dbo.manufacturing_projects
+    ADD custom_fields_json NVARCHAR(MAX) NULL;
+END
+GO
+
+IF OBJECT_ID('dbo.manufacturing_process_steps', 'U') IS NULL
+BEGIN
+    CREATE TABLE dbo.manufacturing_process_steps (
+        id INT IDENTITY(1,1) NOT NULL PRIMARY KEY,
+        step_key NVARCHAR(80) NOT NULL,
+        label NVARCHAR(140) NOT NULL,
+        sort_order INT NOT NULL,
+        require_photo BIT NOT NULL DEFAULT 0,
+        require_comment BIT NOT NULL DEFAULT 0,
+        is_active BIT NOT NULL DEFAULT 1,
+        created_at_utc DATETIME2 NOT NULL DEFAULT SYSUTCDATETIME(),
+        updated_at_utc DATETIME2 NOT NULL DEFAULT SYSUTCDATETIME()
+    );
+END
+GO
+
+IF NOT EXISTS (
+    SELECT 1
+    FROM sys.indexes
+    WHERE object_id = OBJECT_ID('dbo.manufacturing_process_steps')
+      AND name = 'UX_manufacturing_process_steps_step_key'
+)
+BEGIN
+    CREATE UNIQUE INDEX UX_manufacturing_process_steps_step_key
+        ON dbo.manufacturing_process_steps(step_key);
+END
+GO
+
+IF OBJECT_ID('dbo.manufacturing_custom_fields', 'U') IS NULL
+BEGIN
+    CREATE TABLE dbo.manufacturing_custom_fields (
+        id INT IDENTITY(1,1) NOT NULL PRIMARY KEY,
+        field_key NVARCHAR(80) NOT NULL,
+        label NVARCHAR(140) NOT NULL,
+        field_type NVARCHAR(40) NOT NULL DEFAULT 'text',
+        sort_order INT NOT NULL,
+        is_required BIT NOT NULL DEFAULT 0,
+        is_active BIT NOT NULL DEFAULT 1,
+        is_system BIT NOT NULL DEFAULT 0,
+        options_json NVARCHAR(MAX) NULL,
+        created_at_utc DATETIME2 NOT NULL DEFAULT SYSUTCDATETIME(),
+        updated_at_utc DATETIME2 NOT NULL DEFAULT SYSUTCDATETIME()
+    );
+END
+GO
+
+IF NOT EXISTS (
+    SELECT 1
+    FROM sys.indexes
+    WHERE object_id = OBJECT_ID('dbo.manufacturing_custom_fields')
+      AND name = 'UX_manufacturing_custom_fields_field_key'
+)
+BEGIN
+    CREATE UNIQUE INDEX UX_manufacturing_custom_fields_field_key
+        ON dbo.manufacturing_custom_fields(field_key);
+END
+GO
+
+IF NOT EXISTS (SELECT 1 FROM dbo.manufacturing_process_steps)
+BEGIN
+    INSERT INTO dbo.manufacturing_process_steps (step_key, label, sort_order, require_photo, require_comment, is_active)
+    VALUES
+        ('approved', 'Approved', 1, 0, 0, 1),
+        ('sent_to_craftsman', 'Sent To Craftsman', 2, 0, 1, 1),
+        ('internal_setting_qc', 'Internal Setting QC', 3, 1, 1, 1),
+        ('diamond_sorting', 'Diamond Sorting', 4, 1, 0, 1),
+        ('stone_setting', 'Stone Setting', 5, 1, 0, 1),
+        ('plating', 'Plating', 6, 1, 1, 1),
+        ('final_piece_qc', 'Final Piece QC', 7, 1, 1, 1),
+        ('complete_piece', 'Complete Piece', 8, 1, 1, 1),
+        ('ready_for_sale', 'Ready For Sale', 9, 1, 1, 1),
+        ('sold', 'Sold', 10, 0, 1, 1);
+END
+GO
+
+IF NOT EXISTS (SELECT 1 FROM dbo.manufacturing_custom_fields)
+BEGIN
+    INSERT INTO dbo.manufacturing_custom_fields (field_key, label, field_type, sort_order, is_required, is_active, is_system, options_json)
+    VALUES
+        ('designerName', 'Designer', 'text', 1, 0, 1, 1, '[]'),
+        ('craftsmanName', 'Craftsman', 'text', 2, 0, 1, 1, '[]');
+END
+GO

--- a/tools/cosmos/CosmosTools.csproj
+++ b/tools/cosmos/CosmosTools.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/tools/cosmos/Program.cs
+++ b/tools/cosmos/Program.cs
@@ -6,7 +6,9 @@ static void ShowUsage()
     Console.WriteLine("Usage:");
     Console.WriteLine("  dotnet run --project tools/cosmos -- upsert --database <name> --container <name> [--partition-key </path>] [--throughput <ru>]");
     Console.WriteLine("  dotnet run --project tools/cosmos -- ensure-defaults --database <name>");
-    Console.WriteLine("  dotnet run --project tools/cosmos -- seed-user --database <name> --email <email> --password <password>");
+    Console.WriteLine("  dotnet run --project tools/cosmos -- seed-user --database <name> --email <email> --password <password> [--role <admin|member>]");
+    Console.WriteLine("  dotnet run --project tools/cosmos -- list-users --database <name>");
+    Console.WriteLine("  dotnet run --project tools/cosmos -- prune-users --database <name> --keep-emails <comma-separated-emails>");
 }
 
 if (args.Length == 0)
@@ -32,15 +34,8 @@ try
 
     if (command == "upsert")
     {
-        if (!options.TryGetValue("database", out var database) || string.IsNullOrWhiteSpace(database))
+        if (!TryGetRequiredOption(options, "database", out var database) || !TryGetRequiredOption(options, "container", out var container))
         {
-            Console.Error.WriteLine("--database is required");
-            return;
-        }
-
-        if (!options.TryGetValue("container", out var container) || string.IsNullOrWhiteSpace(container))
-        {
-            Console.Error.WriteLine("--container is required");
             return;
         }
 
@@ -63,9 +58,8 @@ try
 
     if (command == "ensure-defaults")
     {
-        if (!options.TryGetValue("database", out var database) || string.IsNullOrWhiteSpace(database))
+        if (!TryGetRequiredOption(options, "database", out var database))
         {
-            Console.Error.WriteLine("--database is required");
             return;
         }
 
@@ -76,21 +70,10 @@ try
 
     if (command == "seed-user")
     {
-        if (!options.TryGetValue("database", out var database) || string.IsNullOrWhiteSpace(database))
+        if (!TryGetRequiredOption(options, "database", out var database) ||
+            !TryGetRequiredOption(options, "email", out var email) ||
+            !TryGetRequiredOption(options, "password", out var password))
         {
-            Console.Error.WriteLine("--database is required");
-            return;
-        }
-
-        if (!options.TryGetValue("email", out var email) || string.IsNullOrWhiteSpace(email))
-        {
-            Console.Error.WriteLine("--email is required");
-            return;
-        }
-
-        if (!options.TryGetValue("password", out var password) || string.IsNullOrWhiteSpace(password))
-        {
-            Console.Error.WriteLine("--password is required");
             return;
         }
 
@@ -98,14 +81,91 @@ try
         var user = await GetUserByEmailAsync(container, email);
         if (user == null)
         {
-            user = new UserRecord { Email = email };
+            user = new UserRecord
+            {
+                Email = NormalizeEmail(email),
+                Role = NormalizeRole(options.TryGetValue("role", out var roleValue) ? roleValue : null),
+                CreatedAtUtc = DateTime.UtcNow
+            };
+        }
+        else
+        {
+            user.Email = NormalizeEmail(email);
+            user.Role = NormalizeRole(options.TryGetValue("role", out var roleValue) ? roleValue : user.Role);
         }
 
         var hasher = new PasswordHasher<UserRecord>();
         user.PasswordHash = hasher.HashPassword(user, password);
+        user.InviteToken = null;
+        user.InviteExpiresAtUtc = null;
+        user.ActivatedAtUtc ??= DateTime.UtcNow;
 
         await container.UpsertItemAsync(user, new PartitionKey(user.id));
-        Console.WriteLine($"Seeded user '{email}' with id '{user.id}'.");
+        Console.WriteLine($"Seeded user '{user.Email}' with id '{user.id}' and role '{user.Role}'.");
+        return;
+    }
+
+    if (command == "list-users")
+    {
+        if (!TryGetRequiredOption(options, "database", out var database))
+        {
+            return;
+        }
+
+        var container = await EnsureContainerAsync(client, database, "users", "/id", null);
+        var users = await GetAllUsersAsync(container);
+
+        Console.WriteLine("id | email | role | status");
+        foreach (var user in users.OrderBy(item => NormalizeEmail(item.Email), StringComparer.OrdinalIgnoreCase))
+        {
+            var status = string.IsNullOrWhiteSpace(user.PasswordHash) ? "invited" : "active";
+            Console.WriteLine($"{user.id} | {NormalizeEmail(user.Email)} | {NormalizeRole(user.Role)} | {status}");
+        }
+
+        Console.WriteLine($"Total users: {users.Count}");
+        return;
+    }
+
+    if (command == "prune-users")
+    {
+        if (!TryGetRequiredOption(options, "database", out var database) ||
+            !TryGetRequiredOption(options, "keep-emails", out var keepEmailsArg))
+        {
+            return;
+        }
+
+        var keepEmails = keepEmailsArg
+            .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .Select(NormalizeEmail)
+            .Where(email => email.Length > 0)
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+        if (keepEmails.Count == 0)
+        {
+            Console.Error.WriteLine("At least one email is required in --keep-emails.");
+            Environment.ExitCode = 1;
+            return;
+        }
+
+        var container = await EnsureContainerAsync(client, database, "users", "/id", null);
+        var users = await GetAllUsersAsync(container);
+        var deleted = 0;
+        var kept = 0;
+
+        foreach (var user in users)
+        {
+            var email = NormalizeEmail(user.Email);
+            if (keepEmails.Contains(email))
+            {
+                kept++;
+                continue;
+            }
+
+            await container.DeleteItemAsync<UserRecord>(user.id, new PartitionKey(user.id));
+            deleted++;
+        }
+
+        Console.WriteLine($"Prune completed. Deleted: {deleted}, kept: {kept}.");
         return;
     }
 
@@ -118,13 +178,26 @@ catch (Exception ex)
     Environment.ExitCode = 1;
 }
 
+static bool TryGetRequiredOption(IReadOnlyDictionary<string, string> options, string key, out string value)
+{
+    if (options.TryGetValue(key, out var rawValue) && !string.IsNullOrWhiteSpace(rawValue))
+    {
+        value = rawValue;
+        return true;
+    }
+
+    Console.Error.WriteLine($"--{key} is required");
+    value = string.Empty;
+    Environment.ExitCode = 1;
+    return false;
+}
+
 static async Task<Container> EnsureContainerAsync(CosmosClient client, string databaseName, string containerName, string partitionKey, int? throughput)
 {
     var databaseResponse = await client.CreateDatabaseIfNotExistsAsync(databaseName);
     var database = databaseResponse.Database;
 
     var properties = new ContainerProperties(containerName, partitionKey);
-
     ContainerResponse containerResponse;
     if (throughput.HasValue)
     {
@@ -140,8 +213,9 @@ static async Task<Container> EnsureContainerAsync(CosmosClient client, string da
 
 static async Task<UserRecord?> GetUserByEmailAsync(Container container, string email)
 {
-    var query = new QueryDefinition("SELECT * FROM c WHERE c.Email = @email")
-        .WithParameter("@email", email.Trim().ToLowerInvariant());
+    var normalizedEmail = NormalizeEmail(email);
+    var query = new QueryDefinition("SELECT * FROM c WHERE LOWER(c.Email) = @email")
+        .WithParameter("@email", normalizedEmail);
     var iterator = container.GetItemQueryIterator<UserRecord>(query);
     while (iterator.HasMoreResults)
     {
@@ -154,6 +228,31 @@ static async Task<UserRecord?> GetUserByEmailAsync(Container container, string e
     }
 
     return null;
+}
+
+static async Task<List<UserRecord>> GetAllUsersAsync(Container container)
+{
+    var users = new List<UserRecord>();
+    var iterator = container.GetItemQueryIterator<UserRecord>(new QueryDefinition("SELECT * FROM c"));
+    while (iterator.HasMoreResults)
+    {
+        var page = await iterator.ReadNextAsync();
+        users.AddRange(page);
+    }
+
+    return users;
+}
+
+static string NormalizeEmail(string? email)
+{
+    return string.IsNullOrWhiteSpace(email) ? string.Empty : email.Trim().ToLowerInvariant();
+}
+
+static string NormalizeRole(string? role)
+{
+    return string.Equals(role?.Trim(), "admin", StringComparison.OrdinalIgnoreCase)
+        ? "admin"
+        : "member";
 }
 
 static Dictionary<string, string> ParseOptions(string[] args)
@@ -182,4 +281,10 @@ internal sealed class UserRecord
     public string id { get; set; } = Guid.NewGuid().ToString();
     public string Email { get; set; } = string.Empty;
     public string PasswordHash { get; set; } = string.Empty;
+    public string Role { get; set; } = "member";
+    public string? InviteToken { get; set; }
+    public DateTime? InviteExpiresAtUtc { get; set; }
+    public DateTime CreatedAtUtc { get; set; } = DateTime.UtcNow;
+    public DateTime? ActivatedAtUtc { get; set; }
+    public DateTime? LastLoginAtUtc { get; set; }
 }

--- a/tools/cosmos/README.md
+++ b/tools/cosmos/README.md
@@ -12,8 +12,22 @@ Simple CLI to provision Cosmos DB resources.
 dotnet run --project tools/cosmos -- ensure-defaults --database houseofrojanatorn
 ```
 
+If only .NET 10 runtime is installed locally, add `-f net10.0` to `dotnet run`.
+
 ## Seed a user
 
 ```bash
 dotnet run --project tools/cosmos -- seed-user --database houseofrojanatorn --email user@example.com --password Password123!
+```
+
+## List users
+
+```bash
+dotnet run --project tools/cosmos -- list-users --database houseofrojanatorn
+```
+
+## Prune users (keep allow-list)
+
+```bash
+dotnet run --project tools/cosmos -- prune-users --database houseofrojanatorn --keep-emails admin@houseofrojanatorn.local
 ```

--- a/tools/db/README.md
+++ b/tools/db/README.md
@@ -24,6 +24,12 @@ dotnet run --project tools/db/SqlRunner -- --file migrations/001_init.sql
 dotnet run --project tools/db/SqlRunner -- --query "SELECT TOP 5 * FROM dbo.app_settings"
 ```
 
+If only .NET 10 runtime is installed locally, add `-f net10.0`:
+
+```bash
+dotnet run --project tools/db/SqlRunner -f net10.0 -- --file migrations/001_init.sql
+```
+
 ## Import Workbook Data
 
 `import_stock_workbook.py` parses the `ROJANATORN GEMS STOCK 2026.xlsx` workbook and writes data into:

--- a/tools/db/SqlRunner/SqlRunner.csproj
+++ b/tools/db/SqlRunner/SqlRunner.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>


### PR DESCRIPTION
Closes #30

## What changed
- Added invite-only user lifecycle backend endpoints (`/users`, `/users/invite`, invite accept/details) with admin checks, status tracking, and last-login updates.
- Added users management UI with invite, role assignment, deletion controls, and invite link generation.
- Added invite acceptance page with first-password setup flow.
- Added manufacturing settings backend + SQL persistence for configurable process steps and dynamic form fields.
- Added settings UI to manage pipeline steps (photo/comment requirements) and field configuration.
- Added migration `004_manufacturing_settings.sql` to support settings tables and project custom fields.
- Added AI-assisted new-project intake flow in manufacturing with upload-first OCR + autofill and manual fallback in full-page layout.
- Updated manufacturing detail/list behavior and status handling to align with configurable steps.
- Hardened direct signup: anonymous `POST /users` now allowed only for first bootstrap user.
- Upgraded tools:
  - `tools/cosmos`: list/prune users and multi-target framework support.
  - `tools/db/SqlRunner`: multi-target framework support.
  - `tools/validation/api_smoke.py`: now validates invite flow + status requirements.

## Data/admin actions completed
- Applied SQL migration `migrations/004_manufacturing_settings.sql` to Azure SQL.
- Rebuilt manufacturing tables from usage import (`tools/db/rebuild_manufacturing_from_usage.sql`) to remove mock data.
- Pruned Cosmos users to keep only `admin@houseofrojanatorn.local`.
- Removed customer rows that were account/test entries (`%@%.local`).

## Validation
- `dotnet build backend/backend.csproj`
- `npm --prefix frontend run build`
- `dotnet build tools/db/SqlRunner/SqlRunner.csproj -f net10.0`
- `dotnet build tools/cosmos/CosmosTools.csproj -f net10.0`
- `DOTNET_ROLL_FORWARD=Major func start` (local Functions host)
- `API_BASE_URL=http://localhost:7071/api SMOKE_ADMIN_EMAIL=admin@houseofrojanatorn.local SMOKE_ADMIN_PASSWORD='Admin!23456' bash tools/validation/run_api_smoke.sh`
