### PR TITLE
Replace popup detail modals with slide-out panels + fullscreen views

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -16,7 +16,7 @@ function ProtectedRoutes() {
   return (
     <Routes>
       <Route path="/" element={<Navigate replace to="/dashboard" />} />
-      <Route path="/dashboard" element={<DashboardPage />} />
+      <Route path="/dashboard/*" element={<DashboardPage />} />
       <Route path="*" element={<NotFoundPage />} />
     </Routes>
   )

--- a/frontend/src/components/dashboard/AnalyticsPanel.tsx
+++ b/frontend/src/components/dashboard/AnalyticsPanel.tsx
@@ -31,9 +31,6 @@ export function AnalyticsPanel() {
   useEffect(() => {
     let cancelled = false
 
-    setIsLoading(true)
-    setError(null)
-
     void getAnalyticsOverview()
       .then(result => {
         if (!cancelled) {

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -370,9 +370,9 @@ a:focus-visible {
 }
 
 .dashboard-main {
-  padding: 1.35rem;
+  padding: 1.85rem;
   display: grid;
-  gap: 0.95rem;
+  gap: 1.2rem;
 }
 
 .page-subtitle {
@@ -393,14 +393,14 @@ a:focus-visible {
 .stats-grid {
   display: grid;
   grid-template-columns: repeat(4, minmax(0, 1fr));
-  gap: 0.8rem;
+  gap: 1rem;
 }
 
 .stats-grid article {
   background: #fff;
   border: 1px solid var(--line);
   border-radius: 13px;
-  padding: 0.82rem;
+  padding: 1rem;
   box-shadow: var(--elev-1);
 }
 
@@ -422,7 +422,7 @@ a:focus-visible {
   background: #fff;
   border: 1px solid var(--line);
   border-radius: 14px;
-  padding: 0.95rem;
+  padding: 1.25rem;
   box-shadow: var(--elev-1);
 }
 
@@ -433,9 +433,9 @@ a:focus-visible {
 .card-head {
   display: flex;
   justify-content: space-between;
-  gap: 0.9rem;
+  gap: 1rem;
   align-items: flex-start;
-  margin-bottom: 0.82rem;
+  margin-bottom: 1rem;
 }
 
 .card-head h3 {
@@ -451,7 +451,7 @@ a:focus-visible {
 .filter-grid {
   display: grid;
   grid-template-columns: repeat(3, minmax(170px, 1fr));
-  gap: 0.5rem;
+  gap: 0.75rem;
 }
 
 .filter-grid input,
@@ -567,17 +567,17 @@ a:focus-visible {
 .usage-table th {
   text-align: left;
   font-weight: 650;
-  font-size: 0.8rem;
+  font-size: 0.83rem;
   color: var(--ink-700);
   border-bottom: 1px solid var(--line);
   background: #f8fafc;
-  padding: 0.58rem 0.5rem;
+  padding: 0.75rem 0.7rem;
 }
 
 .usage-table td {
   border-bottom: 1px solid #eef2f7;
-  padding: 0.58rem 0.5rem;
-  font-size: 0.87rem;
+  padding: 0.75rem 0.7rem;
+  font-size: 0.9rem;
 }
 
 .usage-table tbody tr {
@@ -589,11 +589,11 @@ a:focus-visible {
 }
 
 .table-footer {
-  margin-top: 0.7rem;
+  margin-top: 0.9rem;
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 0.6rem;
+  gap: 0.75rem;
   flex-wrap: wrap;
 }
 
@@ -605,6 +605,44 @@ a:focus-visible {
 
 .detail-drawer {
   margin-top: 0.2rem;
+}
+
+.content-split {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  gap: 1rem;
+  align-items: start;
+}
+
+.content-split.has-detail {
+  grid-template-columns: minmax(0, 1.4fr) minmax(360px, 0.9fr);
+}
+
+.content-split-main {
+  min-width: 0;
+}
+
+.detail-side-panel {
+  background: #fff;
+  border: 1px solid var(--line);
+  border-radius: 14px;
+  box-shadow: var(--elev-1);
+  padding: 1.15rem;
+  position: sticky;
+  top: 1rem;
+  max-height: calc(100vh - 2rem);
+  overflow: auto;
+}
+
+.detail-page-card {
+  min-height: calc(100vh - 170px);
+}
+
+.detail-actions-row {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 0.5rem;
 }
 
 .detail-modal-backdrop {
@@ -640,10 +678,10 @@ a:focus-visible {
 }
 
 .drawer-grid {
-  margin-top: 0.56rem;
+  margin-top: 0.65rem;
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 0.4rem 0.8rem;
+  gap: 0.55rem 1rem;
 }
 
 .drawer-grid p {
@@ -652,7 +690,7 @@ a:focus-visible {
 }
 
 .usage-lines {
-  margin-top: 0.8rem;
+  margin-top: 1rem;
 }
 
 .usage-lines h4 {
@@ -660,29 +698,29 @@ a:focus-visible {
 }
 
 .compact-stats {
-  margin: 0.85rem 0;
+  margin: 1rem 0;
 }
 
 .single-row-filter {
-  margin-bottom: 0.85rem;
+  margin-bottom: 1rem;
   grid-template-columns: minmax(0, 1fr);
 }
 
 .crm-form-grid {
-  margin: 0.85rem 0 1rem;
-  padding: 0.78rem;
+  margin: 1rem 0 1.1rem;
+  padding: 1rem;
   border: 1px solid var(--line);
   border-radius: 12px;
   background: var(--panel-soft);
   display: grid;
-  gap: 0.55rem;
+  gap: 0.75rem;
   grid-template-columns: repeat(2, minmax(0, 1fr));
 }
 
 .crm-form-grid label {
   display: grid;
-  gap: 0.3rem;
-  font-size: 0.82rem;
+  gap: 0.4rem;
+  font-size: 0.86rem;
   color: var(--ink-700);
 }
 
@@ -691,7 +729,7 @@ a:focus-visible {
 .crm-form-grid textarea {
   border: 1px solid var(--line-strong);
   border-radius: 8px;
-  padding: 0.48rem 0.56rem;
+  padding: 0.62rem 0.68rem;
   background: #fff;
   color: var(--ink-900);
   resize: vertical;
@@ -704,7 +742,7 @@ a:focus-visible {
 .crm-form-actions {
   display: flex;
   justify-content: flex-end;
-  gap: 0.45rem;
+  gap: 0.6rem;
 }
 
 .inline-subtext {
@@ -714,7 +752,7 @@ a:focus-visible {
 }
 
 .crm-note-editor {
-  margin-top: 0.8rem;
+  margin-top: 1rem;
 }
 
 .crm-note-editor h4 {
@@ -725,19 +763,19 @@ a:focus-visible {
   width: 100%;
   border: 1px solid var(--line-strong);
   border-radius: 8px;
-  padding: 0.55rem;
+  padding: 0.68rem;
   background: #fff;
 }
 
 .activity-list {
   display: grid;
-  gap: 0.42rem;
+  gap: 0.55rem;
 }
 
 .activity-list article {
   border: 1px solid var(--line);
   border-radius: 10px;
-  padding: 0.5rem 0.6rem;
+  padding: 0.72rem 0.78rem;
   background: #fff;
 }
 
@@ -747,16 +785,17 @@ a:focus-visible {
 }
 
 .status-update-row {
-  margin-top: 0.8rem;
+  margin-top: 1rem;
   display: flex;
   gap: 0.5rem;
   align-items: center;
+  flex-wrap: wrap;
 }
 
 .status-update-row select {
   border: 1px solid var(--line-strong);
   border-radius: 8px;
-  padding: 0.48rem 0.56rem;
+  padding: 0.62rem 0.68rem;
   background: #fff;
 }
 
@@ -813,6 +852,15 @@ a:focus-visible {
 
   .drawer-grid {
     grid-template-columns: 1fr;
+  }
+
+  .content-split.has-detail {
+    grid-template-columns: 1fr;
+  }
+
+  .detail-side-panel {
+    position: static;
+    max-height: none;
   }
 
   .crm-form-grid {

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useState } from 'react'
+import { useLocation, useNavigate } from 'react-router-dom'
 import { getInventoryItem, getInventoryItems, getInventorySummary, getUsageBatches } from '../api/client'
 import type { InventoryItem, InventoryItemDetail, InventorySummary } from '../api/types'
 import { useSession } from '../app/useSession'
@@ -9,8 +10,62 @@ import { PurchasesPanel } from '../components/dashboard/PurchasesPanel'
 import { SettingsPanel } from '../components/dashboard/SettingsPanel'
 import { UsersPanel } from '../components/dashboard/UsersPanel'
 
-type DashboardTab = 'customers' | 'purchases' | 'inventory' | 'manufacturing' | 'usage' | 'analytics' | 'users' | 'settings'
+type DashboardTab = 'customers' | 'purchases' | 'inventory' | 'manufacturing' | 'history' | 'analytics' | 'users' | 'settings'
 const INVENTORY_PAGE_SIZE = 50
+
+const DASHBOARD_TABS: DashboardTab[] = [
+  'customers',
+  'purchases',
+  'inventory',
+  'manufacturing',
+  'history',
+  'analytics',
+  'users',
+  'settings'
+]
+
+function resolveDashboardTab(segment: string | undefined): DashboardTab | null {
+  if (!segment) {
+    return null
+  }
+
+  return DASHBOARD_TABS.includes(segment as DashboardTab)
+    ? (segment as DashboardTab)
+    : null
+}
+
+function parseInventoryRoute(pathname: string): { detailId: number | null, isFull: boolean, isInvalid: boolean } {
+  const parts = pathname.split('/').filter(Boolean)
+  if (parts[0] !== 'dashboard' || parts[1] !== 'inventory') {
+    return { detailId: null, isFull: false, isInvalid: false }
+  }
+
+  const detailSegment = parts[2]
+  const fullSegment = parts[3]
+
+  if (!detailSegment) {
+    return {
+      detailId: null,
+      isFull: false,
+      isInvalid: parts.length > 2
+    }
+  }
+
+  const detailId = Number(detailSegment)
+  if (!Number.isInteger(detailId) || detailId <= 0) {
+    return { detailId: null, isFull: false, isInvalid: true }
+  }
+
+  if (fullSegment && fullSegment !== 'full') {
+    return { detailId, isFull: false, isInvalid: true }
+  }
+
+  return {
+    detailId,
+    isFull: fullSegment === 'full',
+    isInvalid: parts.length > 4
+  }
+}
 
 function formatCurrency(value: number | null | undefined): string {
   if (typeof value !== 'number' || !Number.isFinite(value)) {
@@ -49,10 +104,142 @@ function formatNumber(value: number | null | undefined, digits = 2): string {
   return value.toFixed(digits)
 }
 
+function InventoryDetailContent({ selectedInventory }: { selectedInventory: InventoryItemDetail }) {
+  return (
+    <>
+      <div className="usage-lines">
+        <h4>Details</h4>
+        <div className="drawer-grid">
+          <p><strong>Inventory ID:</strong> {selectedInventory.id}</p>
+          <p><strong>Code:</strong> {selectedInventory.gemstoneNumber ?? selectedInventory.gemstoneNumberText ?? '-'}</p>
+          <p><strong>Type:</strong> {selectedInventory.gemstoneType ?? '-'}</p>
+          <p><strong>Shape:</strong> {selectedInventory.shape ?? '-'}</p>
+          <p><strong>Buying Date:</strong> {formatDate(selectedInventory.buyingDate)}</p>
+          <p><strong>Owner:</strong> {selectedInventory.ownerName ?? '-'}</p>
+          <p><strong>Raw Weight/PCS:</strong> {selectedInventory.weightPcsRaw ?? '-'}</p>
+          <p><strong>Raw Price/CT:</strong> {selectedInventory.pricePerCtRaw ?? '-'}</p>
+          <p><strong>Raw Price/PC:</strong> {selectedInventory.pricePerPieceRaw ?? '-'}</p>
+          <p><strong>Balance CT:</strong> {formatNumber(selectedInventory.effectiveBalanceCt, 2)}</p>
+          <p><strong>Balance PCS:</strong> {formatNumber(selectedInventory.effectiveBalancePcs, 0)}</p>
+          <p><strong>Parsed Weight CT:</strong> {formatNumber(selectedInventory.parsedWeightCt, 2)}</p>
+          <p><strong>Parsed Qty PCS:</strong> {formatNumber(selectedInventory.parsedQuantityPcs, 0)}</p>
+          <p><strong>Parsed Price/CT:</strong> {formatNumber(selectedInventory.parsedPricePerCt, 2)}</p>
+          <p><strong>Parsed Price/PC:</strong> {formatNumber(selectedInventory.parsedPricePerPiece, 2)}</p>
+        </div>
+      </div>
+
+      <div className="usage-lines">
+        <h4>
+          Manufacturing Activities
+          {' '}
+          ({selectedInventory.manufacturingActivities.length})
+        </h4>
+        {selectedInventory.manufacturingActivities.length === 0 ? (
+          <p className="panel-placeholder">No manufacturing activity found for this gemstone.</p>
+        ) : (
+          <div className="activity-list">
+            {selectedInventory.manufacturingActivities.map((activity, index) => (
+              <article key={`${activity.projectId}-${activity.activityAtUtc ?? 'activity'}-${index}`}>
+                <p>
+                  <strong>{activity.manufacturingCode}</strong>
+                  {' • '}
+                  {activity.pieceName}
+                </p>
+                <p>
+                  {activity.status}
+                  {' • '}
+                  {formatDate(activity.activityAtUtc)}
+                </p>
+                <p>
+                  Used
+                  {' '}
+                  {formatNumber(activity.piecesUsed, 0)}
+                  {' '}
+                  pcs /
+                  {' '}
+                  {formatNumber(activity.weightUsedCt, 2)}
+                  {' '}
+                  ct
+                  {' • '}
+                  Line Cost
+                  {' '}
+                  {formatCurrency(activity.lineCost)}
+                </p>
+                {activity.craftsmanName ? <p>Craftsman: {activity.craftsmanName}</p> : null}
+                {activity.notes ? <p>{activity.notes}</p> : null}
+              </article>
+            ))}
+          </div>
+        )}
+      </div>
+
+      <div className="usage-lines">
+        <h4>
+          Usage Activities
+          {' '}
+          ({selectedInventory.usageActivities.length})
+        </h4>
+        {selectedInventory.usageActivities.length === 0 ? (
+          <p className="panel-placeholder">No usage history found for this gemstone.</p>
+        ) : (
+          <div className="activity-list">
+            {selectedInventory.usageActivities.map(activity => (
+              <article key={activity.lineId}>
+                <p>
+                  <strong>{activity.productCode ?? '-'}</strong>
+                  {' • '}
+                  {activity.productCategory || 'uncategorized'}
+                </p>
+                <p>
+                  {formatDate(activity.transactionDate)}
+                  {' • '}
+                  {activity.requesterName ?? '-'}
+                </p>
+                <p>
+                  Used
+                  {' '}
+                  {formatNumber(activity.usedPcs, 0)}
+                  {' '}
+                  pcs /
+                  {' '}
+                  {formatNumber(activity.usedWeightCt, 2)}
+                  {' '}
+                  ct
+                </p>
+                <p>
+                  Line Amount
+                  {' '}
+                  {formatCurrency(activity.lineAmount)}
+                  {' • '}
+                  Balance After
+                  {' '}
+                  {formatNumber(activity.balancePcsAfter, 0)}
+                  {' '}
+                  pcs /
+                  {' '}
+                  {formatNumber(activity.balanceCtAfter, 2)}
+                  {' '}
+                  ct
+                </p>
+              </article>
+            ))}
+          </div>
+        )}
+      </div>
+    </>
+  )
+}
+
 export function DashboardPage() {
+  const location = useLocation()
+  const navigate = useNavigate()
   const { email, role, signOut } = useSession()
-  const [activeTab, setActiveTab] = useState<DashboardTab>('customers')
   const [isSidebarCollapsed, setIsSidebarCollapsed] = useState(false)
+
+  const routeParts = useMemo(() => location.pathname.split('/').filter(Boolean), [location.pathname])
+  const routeTab = useMemo(() => resolveDashboardTab(routeParts[1]), [routeParts])
+  const activeTab = routeTab ?? 'customers'
+  const inventoryRoute = useMemo(() => parseInventoryRoute(location.pathname), [location.pathname])
 
   const [summary, setSummary] = useState<InventorySummary | null>(null)
   const [inventory, setInventory] = useState<InventoryItem[]>([])
@@ -67,9 +254,26 @@ export function DashboardPage() {
 
   const [isLoadingSummary, setIsLoadingSummary] = useState(true)
   const [isLoadingInventory, setIsLoadingInventory] = useState(true)
+  const [isLoadingInventoryDetail, setIsLoadingInventoryDetail] = useState(false)
   const [isLoadingMoreInventory, setIsLoadingMoreInventory] = useState(false)
   const [isLoadingUsage, setIsLoadingUsage] = useState(true)
   const [errorMessage, setErrorMessage] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (routeParts[0] !== 'dashboard' || !routeTab) {
+      navigate('/dashboard/customers', { replace: true })
+    }
+  }, [navigate, routeParts, routeTab])
+
+  useEffect(() => {
+    if (inventoryRoute.isInvalid) {
+      navigate('/dashboard/inventory', { replace: true })
+    }
+  }, [inventoryRoute.isInvalid, navigate])
+
+  function goToTab(tab: DashboardTab) {
+    navigate(`/dashboard/${tab}`)
+  }
 
   useEffect(() => {
     let cancelled = false
@@ -97,12 +301,17 @@ export function DashboardPage() {
   }, [])
 
   useEffect(() => {
+    if (activeTab !== 'inventory') {
+      return
+    }
+
     let cancelled = false
     setIsLoadingInventory(true)
     setErrorMessage(null)
     setInventory([])
     setInventoryTotal(0)
     setInventoryOffset(0)
+
     void getInventoryItems({
       search: inventorySearch,
       type: inventoryType,
@@ -131,9 +340,13 @@ export function DashboardPage() {
     return () => {
       cancelled = true
     }
-  }, [inventorySearch, inventoryStatus, inventoryType])
+  }, [activeTab, inventorySearch, inventoryStatus, inventoryType])
 
   useEffect(() => {
+    if (activeTab !== 'history') {
+      return
+    }
+
     let cancelled = false
     setIsLoadingUsage(true)
     void getUsageBatches({
@@ -159,22 +372,41 @@ export function DashboardPage() {
     return () => {
       cancelled = true
     }
-  }, [])
-
-  useEffect(() => {
-    if (activeTab !== 'inventory') {
-      setSelectedInventory(null)
-    }
   }, [activeTab])
 
-  async function openInventoryDetail(itemId: number) {
-    try {
-      const detail = await getInventoryItem(itemId)
-      setSelectedInventory(detail)
-    } catch {
-      setErrorMessage('Unable to load selected inventory item.')
+  useEffect(() => {
+    if (activeTab !== 'inventory' || !inventoryRoute.detailId) {
+      setSelectedInventory(null)
+      setIsLoadingInventoryDetail(false)
+      return
     }
-  }
+
+    let cancelled = false
+    setIsLoadingInventoryDetail(true)
+    setErrorMessage(null)
+
+    void getInventoryItem(inventoryRoute.detailId)
+      .then(detail => {
+        if (!cancelled) {
+          setSelectedInventory(detail)
+        }
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setErrorMessage('Unable to load selected inventory item.')
+          setSelectedInventory(null)
+        }
+      })
+      .finally(() => {
+        if (!cancelled) {
+          setIsLoadingInventoryDetail(false)
+        }
+      })
+
+    return () => {
+      cancelled = true
+    }
+  }, [activeTab, inventoryRoute.detailId])
 
   async function loadMoreInventory() {
     if (isLoadingInventory || isLoadingMoreInventory || inventory.length >= inventoryTotal) {
@@ -222,13 +454,166 @@ export function DashboardPage() {
           ? 'Invite, activate, and manage platform users and roles.'
           : activeTab === 'settings'
             ? 'Configure production steps and dynamic manufacturing form fields.'
-        : activeTab === 'purchases'
-          ? 'Sold records derived from manufacturing projects with status = sold.'
-          : activeTab === 'analytics'
-            ? 'Business metrics generated from sold projects and customer activity.'
-            : activeTab === 'usage'
-              ? 'Historical import has been migrated into manufacturing records.'
-              : 'Mapped from real 2026 stock workbook and Azure SQL data.'
+            : activeTab === 'purchases'
+              ? 'Sold records derived from manufacturing projects with status = sold.'
+              : activeTab === 'analytics'
+                ? 'Business metrics generated from sold projects and customer activity.'
+                : activeTab === 'history'
+                  ? 'Historical import has been migrated into manufacturing records.'
+                  : 'Mapped from real 2026 stock workbook and Azure SQL data.'
+
+  function openInventoryDetail(itemId: number) {
+    navigate(`/dashboard/inventory/${itemId}`)
+  }
+
+  function closeInventoryDetail() {
+    navigate('/dashboard/inventory')
+  }
+
+  function openInventoryFullDetail() {
+    if (!inventoryRoute.detailId) {
+      return
+    }
+
+    navigate(`/dashboard/inventory/${inventoryRoute.detailId}/full`)
+  }
+
+  function closeInventoryFullDetail() {
+    if (!inventoryRoute.detailId) {
+      navigate('/dashboard/inventory')
+      return
+    }
+
+    navigate(`/dashboard/inventory/${inventoryRoute.detailId}`)
+  }
+
+  const inventoryListCard = (
+    <section className="content-card">
+      <div className="card-head">
+        <div>
+          <h3>Gemstone Inventory</h3>
+          <p>{inventoryTotal.toLocaleString()} records loaded from Azure SQL</p>
+        </div>
+        <div className="filter-grid">
+          <input
+            placeholder="Search type, shape, owner, or code"
+            value={inventorySearch}
+            onChange={event => setInventorySearch(event.target.value)}
+          />
+          <select value={inventoryType} onChange={event => setInventoryType(event.target.value)}>
+            <option value="all">All types</option>
+            {uniqueGemTypes.map(value => (
+              <option key={value} value={value}>
+                {value}
+              </option>
+            ))}
+          </select>
+          <select value={inventoryStatus} onChange={event => setInventoryStatus(event.target.value)}>
+            <option value="all">All status</option>
+            <option value="available">Available</option>
+            <option value="low-stock">Low stock</option>
+            <option value="out-of-stock">Out of stock</option>
+          </select>
+        </div>
+      </div>
+
+      {isLoadingInventory ? (
+        <p className="panel-placeholder">Loading inventory data...</p>
+      ) : inventory.length === 0 ? (
+        <p className="panel-placeholder">No gemstones match the current filters.</p>
+      ) : (
+        <>
+          <div className="usage-table-wrap">
+            <table className="usage-table">
+              <thead>
+                <tr>
+                  <th>Gem #</th>
+                  <th>Type</th>
+                  <th>Shape</th>
+                  <th>Owner</th>
+                  <th>Buying Date</th>
+                  <th>Balance (CT)</th>
+                  <th>Balance (PCS)</th>
+                  <th>Status</th>
+                </tr>
+              </thead>
+              <tbody>
+                {inventory.map(item => {
+                  const statusClass =
+                    item.effectiveBalanceCt > 1 || item.effectiveBalancePcs > 10
+                      ? 'ok'
+                      : item.effectiveBalanceCt > 0 || item.effectiveBalancePcs > 0
+                        ? 'low'
+                        : 'out'
+
+                  return (
+                    <tr key={item.id} onClick={() => openInventoryDetail(item.id)}>
+                      <td>{item.gemstoneNumber ?? item.gemstoneNumberText ?? item.id}</td>
+                      <td>{item.gemstoneType ?? '-'}</td>
+                      <td>{item.shape ?? '-'}</td>
+                      <td>{item.ownerName ?? '-'}</td>
+                      <td>{formatDate(item.buyingDate)}</td>
+                      <td>{(item.effectiveBalanceCt ?? 0).toFixed(2)}</td>
+                      <td>{(item.effectiveBalancePcs ?? 0).toFixed(0)}</td>
+                      <td>
+                        <span className={`stock-pill ${statusClass}`}>
+                          {statusClass === 'ok' ? 'Available' : statusClass === 'low' ? 'Low' : 'Out'}
+                        </span>
+                      </td>
+                    </tr>
+                  )
+                })}
+              </tbody>
+            </table>
+          </div>
+
+          <div className="table-footer">
+            <p>
+              Showing
+              {' '}
+              {inventory.length.toLocaleString()}
+              {' '}
+              of
+              {' '}
+              {inventoryTotal.toLocaleString()}
+              {' '}
+              records
+            </p>
+            {inventory.length < inventoryTotal ? (
+              <button type="button" className="secondary-btn" onClick={() => void loadMoreInventory()} disabled={isLoadingMoreInventory}>
+                {isLoadingMoreInventory ? 'Loading...' : 'See more'}
+              </button>
+            ) : null}
+          </div>
+        </>
+      )}
+    </section>
+  )
+
+  const historyCard = (
+    <section className="content-card">
+      <div className="card-head">
+        <div>
+          <h3>History Moved To Manufacturing</h3>
+          <p>Imported records are now treated as manufacturing projects.</p>
+        </div>
+        <button type="button" className="primary-btn" onClick={() => navigate('/dashboard/manufacturing')}>
+          Open Manufacturing
+        </button>
+      </div>
+
+      <p className="panel-placeholder">
+        The old history dataset has been migrated into Manufacturing.
+        {' '}
+        Click any row in the Manufacturing tab to view full imported details (lines, costs, and notes).
+      </p>
+      <p className="panel-placeholder">
+        Archived raw usage batches currently stored:
+        {' '}
+        {isLoadingUsage ? '...' : usageTotal.toLocaleString()}
+      </p>
+    </section>
+  )
 
   return (
     <main className={`dashboard-shell ${isSidebarCollapsed ? 'sidebar-collapsed' : ''}`}>
@@ -254,35 +639,35 @@ export function DashboardPage() {
         </div>
 
         <nav className="sidebar-nav">
-          <button type="button" className={activeTab === 'customers' ? 'active' : ''} onClick={() => setActiveTab('customers')}>
+          <button type="button" className={activeTab === 'customers' ? 'active' : ''} onClick={() => goToTab('customers')}>
             <span className="label-full">Customers</span>
             <span className="label-short">CU</span>
           </button>
-          <button type="button" className={activeTab === 'purchases' ? 'active' : ''} onClick={() => setActiveTab('purchases')}>
+          <button type="button" className={activeTab === 'purchases' ? 'active' : ''} onClick={() => goToTab('purchases')}>
             <span className="label-full">Purchases</span>
             <span className="label-short">PU</span>
           </button>
-          <button type="button" className={activeTab === 'inventory' ? 'active' : ''} onClick={() => setActiveTab('inventory')}>
+          <button type="button" className={activeTab === 'inventory' ? 'active' : ''} onClick={() => goToTab('inventory')}>
             <span className="label-full">Gemstones</span>
             <span className="label-short">GE</span>
           </button>
-          <button type="button" className={activeTab === 'manufacturing' ? 'active' : ''} onClick={() => setActiveTab('manufacturing')}>
+          <button type="button" className={activeTab === 'manufacturing' ? 'active' : ''} onClick={() => goToTab('manufacturing')}>
             <span className="label-full">Manufacturing</span>
             <span className="label-short">MF</span>
           </button>
-          <button type="button" className={activeTab === 'usage' ? 'active' : ''} onClick={() => setActiveTab('usage')}>
+          <button type="button" className={activeTab === 'history' ? 'active' : ''} onClick={() => goToTab('history')}>
             <span className="label-full">History</span>
             <span className="label-short">HI</span>
           </button>
-          <button type="button" className={activeTab === 'analytics' ? 'active' : ''} onClick={() => setActiveTab('analytics')}>
+          <button type="button" className={activeTab === 'analytics' ? 'active' : ''} onClick={() => goToTab('analytics')}>
             <span className="label-full">Analytics</span>
             <span className="label-short">AN</span>
           </button>
-          <button type="button" className={activeTab === 'users' ? 'active' : ''} onClick={() => setActiveTab('users')}>
+          <button type="button" className={activeTab === 'users' ? 'active' : ''} onClick={() => goToTab('users')}>
             <span className="label-full">Users</span>
             <span className="label-short">US</span>
           </button>
-          <button type="button" className={activeTab === 'settings' ? 'active' : ''} onClick={() => setActiveTab('settings')}>
+          <button type="button" className={activeTab === 'settings' ? 'active' : ''} onClick={() => goToTab('settings')}>
             <span className="label-full">Settings</span>
             <span className="label-short">SE</span>
           </button>
@@ -304,7 +689,7 @@ export function DashboardPage() {
 
         {errorMessage ? <p className="error-banner">{errorMessage}</p> : null}
 
-        {(activeTab === 'inventory' || activeTab === 'usage') ? (
+        {(activeTab === 'inventory' || activeTab === 'history') ? (
           <section className="stats-grid">
             <article>
               <h3>Total Gem Entries</h3>
@@ -338,268 +723,65 @@ export function DashboardPage() {
         ) : activeTab === 'settings' ? (
           <SettingsPanel />
         ) : activeTab === 'inventory' ? (
-          <section className="content-card">
-            <div className="card-head">
-              <div>
-                <h3>Gemstone Inventory</h3>
-                <p>{inventoryTotal.toLocaleString()} records loaded from Azure SQL</p>
-              </div>
-              <div className="filter-grid">
-                <input
-                  placeholder="Search type, shape, owner, or code"
-                  value={inventorySearch}
-                  onChange={event => setInventorySearch(event.target.value)}
-                />
-                <select value={inventoryType} onChange={event => setInventoryType(event.target.value)}>
-                  <option value="all">All types</option>
-                  {uniqueGemTypes.map(value => (
-                    <option key={value} value={value}>
-                      {value}
-                    </option>
-                  ))}
-                </select>
-                <select value={inventoryStatus} onChange={event => setInventoryStatus(event.target.value)}>
-                  <option value="all">All status</option>
-                  <option value="available">Available</option>
-                  <option value="low-stock">Low stock</option>
-                  <option value="out-of-stock">Out of stock</option>
-                </select>
-              </div>
-            </div>
-
-            {isLoadingInventory ? (
-              <p className="panel-placeholder">Loading inventory data...</p>
-            ) : inventory.length === 0 ? (
-              <p className="panel-placeholder">No gemstones match the current filters.</p>
-            ) : (
-              <>
-                <div className="usage-table-wrap">
-                  <table className="usage-table">
-                    <thead>
-                      <tr>
-                        <th>Gem #</th>
-                        <th>Type</th>
-                        <th>Shape</th>
-                        <th>Owner</th>
-                        <th>Buying Date</th>
-                        <th>Balance (CT)</th>
-                        <th>Balance (PCS)</th>
-                        <th>Status</th>
-                      </tr>
-                    </thead>
-                    <tbody>
-                      {inventory.map(item => {
-                        const statusClass =
-                          item.effectiveBalanceCt > 1 || item.effectiveBalancePcs > 10
-                            ? 'ok'
-                            : item.effectiveBalanceCt > 0 || item.effectiveBalancePcs > 0
-                              ? 'low'
-                              : 'out'
-
-                        return (
-                          <tr key={item.id} onClick={() => void openInventoryDetail(item.id)}>
-                            <td>{item.gemstoneNumber ?? item.gemstoneNumberText ?? item.id}</td>
-                            <td>{item.gemstoneType ?? '-'}</td>
-                            <td>{item.shape ?? '-'}</td>
-                            <td>{item.ownerName ?? '-'}</td>
-                            <td>{formatDate(item.buyingDate)}</td>
-                            <td>{(item.effectiveBalanceCt ?? 0).toFixed(2)}</td>
-                            <td>{(item.effectiveBalancePcs ?? 0).toFixed(0)}</td>
-                            <td>
-                              <span className={`stock-pill ${statusClass}`}>
-                                {statusClass === 'ok' ? 'Available' : statusClass === 'low' ? 'Low' : 'Out'}
-                              </span>
-                            </td>
-                          </tr>
-                        )
-                      })}
-                    </tbody>
-                  </table>
+          inventoryRoute.isFull ? (
+            <section className="content-card detail-page-card">
+              <div className="card-head">
+                <div>
+                  <h3>Gemstone Detail</h3>
+                  <p>Full page gemstone detail and activity trail.</p>
                 </div>
-
-                <div className="table-footer">
-                  <p>
-                    Showing
-                    {' '}
-                    {inventory.length.toLocaleString()}
-                    {' '}
-                    of
-                    {' '}
-                    {inventoryTotal.toLocaleString()}
-                    {' '}
-                    records
-                  </p>
-                  {inventory.length < inventoryTotal ? (
-                    <button type="button" className="secondary-btn" onClick={() => void loadMoreInventory()} disabled={isLoadingMoreInventory}>
-                      {isLoadingMoreInventory ? 'Loading...' : 'See more'}
-                    </button>
-                  ) : null}
-                </div>
-              </>
-            )}
-          </section>
-        ) : (
-          <section className="content-card">
-            <div className="card-head">
-              <div>
-                <h3>History Moved To Manufacturing</h3>
-                <p>Imported records are now treated as manufacturing projects.</p>
-              </div>
-              <button type="button" className="primary-btn" onClick={() => setActiveTab('manufacturing')}>
-                Open Manufacturing
-              </button>
-            </div>
-
-            <p className="panel-placeholder">
-              The old history dataset has been migrated into Manufacturing.
-              {' '}
-              Click any row in the Manufacturing tab to view full imported details (lines, costs, and notes).
-            </p>
-            <p className="panel-placeholder">
-              Archived raw usage batches currently stored:
-              {' '}
-              {isLoadingUsage ? '...' : usageTotal.toLocaleString()}
-            </p>
-          </section>
-        )}
-
-        {selectedInventory ? (
-          <div className="detail-modal-backdrop" onClick={() => setSelectedInventory(null)}>
-            <section className="detail-modal-panel" onClick={event => event.stopPropagation()}>
-              <div className="drawer-head">
-                <h3>
-                  Gemstone
-                  {' '}
-                  {selectedInventory.gemstoneNumber ?? selectedInventory.gemstoneNumberText ?? selectedInventory.id}
-                </h3>
-                <button type="button" className="secondary-btn" onClick={() => setSelectedInventory(null)}>
-                  Close
-                </button>
-              </div>
-
-              <div className="usage-lines">
-                <h4>Details</h4>
-                <div className="drawer-grid">
-                  <p><strong>Inventory ID:</strong> {selectedInventory.id}</p>
-                  <p><strong>Code:</strong> {selectedInventory.gemstoneNumber ?? selectedInventory.gemstoneNumberText ?? '-'}</p>
-                  <p><strong>Type:</strong> {selectedInventory.gemstoneType ?? '-'}</p>
-                  <p><strong>Shape:</strong> {selectedInventory.shape ?? '-'}</p>
-                  <p><strong>Buying Date:</strong> {formatDate(selectedInventory.buyingDate)}</p>
-                  <p><strong>Owner:</strong> {selectedInventory.ownerName ?? '-'}</p>
-                  <p><strong>Raw Weight/PCS:</strong> {selectedInventory.weightPcsRaw ?? '-'}</p>
-                  <p><strong>Raw Price/CT:</strong> {selectedInventory.pricePerCtRaw ?? '-'}</p>
-                  <p><strong>Raw Price/PC:</strong> {selectedInventory.pricePerPieceRaw ?? '-'}</p>
-                  <p><strong>Balance CT:</strong> {formatNumber(selectedInventory.effectiveBalanceCt, 2)}</p>
-                  <p><strong>Balance PCS:</strong> {formatNumber(selectedInventory.effectiveBalancePcs, 0)}</p>
-                  <p><strong>Parsed Weight CT:</strong> {formatNumber(selectedInventory.parsedWeightCt, 2)}</p>
-                  <p><strong>Parsed Qty PCS:</strong> {formatNumber(selectedInventory.parsedQuantityPcs, 0)}</p>
-                  <p><strong>Parsed Price/CT:</strong> {formatNumber(selectedInventory.parsedPricePerCt, 2)}</p>
-                  <p><strong>Parsed Price/PC:</strong> {formatNumber(selectedInventory.parsedPricePerPiece, 2)}</p>
+                <div className="detail-actions-row">
+                  <button type="button" className="secondary-btn" onClick={closeInventoryFullDetail}>
+                    Back To Split View
+                  </button>
+                  <button type="button" className="secondary-btn" onClick={closeInventoryDetail}>
+                    Back To Table
+                  </button>
                 </div>
               </div>
 
-              <div className="usage-lines">
-                <h4>
-                  Manufacturing Activities
-                  {' '}
-                  ({selectedInventory.manufacturingActivities.length})
-                </h4>
-                {selectedInventory.manufacturingActivities.length === 0 ? (
-                  <p className="panel-placeholder">No manufacturing activity found for this gemstone.</p>
-                ) : (
-                  <div className="activity-list">
-                    {selectedInventory.manufacturingActivities.map((activity, index) => (
-                      <article key={`${activity.projectId}-${activity.activityAtUtc ?? 'activity'}-${index}`}>
-                        <p>
-                          <strong>{activity.manufacturingCode}</strong>
-                          {' • '}
-                          {activity.pieceName}
-                        </p>
-                        <p>
-                          {activity.status}
-                          {' • '}
-                          {formatDate(activity.activityAtUtc)}
-                        </p>
-                        <p>
-                          Used
-                          {' '}
-                          {formatNumber(activity.piecesUsed, 0)}
-                          {' '}
-                          pcs /
-                          {' '}
-                          {formatNumber(activity.weightUsedCt, 2)}
-                          {' '}
-                          ct
-                          {' • '}
-                          Line Cost
-                          {' '}
-                          {formatCurrency(activity.lineCost)}
-                        </p>
-                        {activity.craftsmanName ? <p>Craftsman: {activity.craftsmanName}</p> : null}
-                        {activity.notes ? <p>{activity.notes}</p> : null}
-                      </article>
-                    ))}
-                  </div>
-                )}
-              </div>
-
-              <div className="usage-lines">
-                <h4>
-                  Usage Activities
-                  {' '}
-                  ({selectedInventory.usageActivities.length})
-                </h4>
-                {selectedInventory.usageActivities.length === 0 ? (
-                  <p className="panel-placeholder">No usage history found for this gemstone.</p>
-                ) : (
-                  <div className="activity-list">
-                    {selectedInventory.usageActivities.map(activity => (
-                      <article key={activity.lineId}>
-                        <p>
-                          <strong>{activity.productCode ?? '-'}</strong>
-                          {' • '}
-                          {activity.productCategory || 'uncategorized'}
-                        </p>
-                        <p>
-                          {formatDate(activity.transactionDate)}
-                          {' • '}
-                          {activity.requesterName ?? '-'}
-                        </p>
-                        <p>
-                          Used
-                          {' '}
-                          {formatNumber(activity.usedPcs, 0)}
-                          {' '}
-                          pcs /
-                          {' '}
-                          {formatNumber(activity.usedWeightCt, 2)}
-                          {' '}
-                          ct
-                        </p>
-                        <p>
-                          Line Amount
-                          {' '}
-                          {formatCurrency(activity.lineAmount)}
-                          {' • '}
-                          Balance After
-                          {' '}
-                          {formatNumber(activity.balancePcsAfter, 0)}
-                          {' '}
-                          pcs /
-                          {' '}
-                          {formatNumber(activity.balanceCtAfter, 2)}
-                          {' '}
-                          ct
-                        </p>
-                      </article>
-                    ))}
-                  </div>
-                )}
-              </div>
+              {isLoadingInventoryDetail ? (
+                <p className="panel-placeholder">Loading inventory detail...</p>
+              ) : selectedInventory ? (
+                <InventoryDetailContent selectedInventory={selectedInventory} />
+              ) : (
+                <p className="panel-placeholder">No inventory detail found for this route.</p>
+              )}
             </section>
-          </div>
-        ) : null}
+          ) : (
+            <div className={`content-split ${inventoryRoute.detailId ? 'has-detail' : ''}`}>
+              <div className="content-split-main">
+                {inventoryListCard}
+              </div>
 
+              {inventoryRoute.detailId ? (
+                <aside className="detail-side-panel">
+                  <div className="drawer-head">
+                    <h3>Gemstone Detail</h3>
+                    <div className="detail-actions-row">
+                      <button type="button" className="secondary-btn" onClick={openInventoryFullDetail}>
+                        Full Screen
+                      </button>
+                      <button type="button" className="secondary-btn" onClick={closeInventoryDetail}>
+                        Close
+                      </button>
+                    </div>
+                  </div>
+
+                  {isLoadingInventoryDetail ? (
+                    <p className="panel-placeholder">Loading inventory detail...</p>
+                  ) : selectedInventory ? (
+                    <InventoryDetailContent selectedInventory={selectedInventory} />
+                  ) : (
+                    <p className="panel-placeholder">No inventory detail found for this record.</p>
+                  )}
+                </aside>
+              ) : null}
+            </div>
+          )
+        ) : (
+          historyCard
+        )}
       </section>
     </main>
   )


### PR DESCRIPTION
Closes #32

## What changed
- switched dashboard routing to URL-driven section/detail/fullscreen paths
- replaced modal detail overlays with right-side slide-out panels on:
  - gemstones inventory
  - manufacturing
  - purchases
  - customers
- added `Full Screen` actions to each slide-out panel and full-page detail routes
- updated dashboard layout spacing/padding and split-panel styles for cleaner UI

## Validation
- `npm --prefix frontend run build` ✅
- `npm --prefix frontend run lint` ⚠️ repo currently enforces `react-hooks/set-state-in-effect`; existing route-loading pattern still flags in `frontend/src/components/dashboard/PurchasesPanel.tsx`