### PR TITLE
Manufacturing settings/workforce revamp + per-step photo evidence

### DIFF
--- a/backend/Models/CustomerManufacturingModels.cs
+++ b/backend/Models/CustomerManufacturingModels.cs
@@ -70,6 +70,34 @@ public static class ManufacturingPieceTypes
     }
 }
 
+public static class ManufacturingPersonRoles
+{
+    public const string Designer = "designer";
+    public const string Craftsman = "craftsman";
+
+    public static string NormalizeOrDefault(string? value, string fallback = Designer)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return fallback;
+        }
+
+        var normalized = value.Trim().ToLowerInvariant();
+        return normalized switch
+        {
+            Designer => Designer,
+            Craftsman => Craftsman,
+            _ => fallback
+        };
+    }
+
+    public static bool IsValid(string? value)
+    {
+        var normalized = NormalizeOrDefault(value, string.Empty);
+        return normalized == Designer || normalized == Craftsman;
+    }
+}
+
 public sealed class CustomerResponse
 {
     public Guid Id { get; init; }
@@ -135,6 +163,7 @@ public sealed class ManufacturingActivityLogResponse
     public DateTime ActivityAtUtc { get; init; }
     public string? CraftsmanName { get; init; }
     public string? Notes { get; init; }
+    public IReadOnlyList<string> Photos { get; init; } = [];
 }
 
 public sealed class ManufacturingProjectSummaryResponse
@@ -227,7 +256,35 @@ public sealed class ManufacturingProjectUpsertRequest
     public DateTime? SoldAt { get; init; }
     public IReadOnlyList<ManufacturingGemstoneUpsertRequest>? Gemstones { get; init; }
     public string? ActivityNote { get; init; }
+    public IReadOnlyList<string>? ActivityPhotos { get; init; }
     public IReadOnlyDictionary<string, string?>? CustomFields { get; init; }
+}
+
+public sealed class ManufacturingPersonResponse
+{
+    public int Id { get; init; }
+    public string Role { get; init; } = ManufacturingPersonRoles.Designer;
+    public string Name { get; init; } = string.Empty;
+    public string? Email { get; init; }
+    public string? Phone { get; init; }
+    public bool IsActive { get; init; }
+    public DateTime CreatedAtUtc { get; init; }
+    public DateTime UpdatedAtUtc { get; init; }
+}
+
+public sealed class ManufacturingPersonUpsertRequest
+{
+    public string? Role { get; init; }
+    public string? Name { get; init; }
+    public string? Email { get; init; }
+    public string? Phone { get; init; }
+    public bool? IsActive { get; init; }
+}
+
+public sealed class ManufacturingPersonProfileResponse
+{
+    public ManufacturingPersonResponse Person { get; init; } = new();
+    public IReadOnlyList<ManufacturingProjectSummaryResponse> Projects { get; init; } = [];
 }
 
 public sealed class ManufacturingProcessStepResponse
@@ -256,6 +313,8 @@ public sealed class ManufacturingSettingsResponse
 {
     public IReadOnlyList<ManufacturingProcessStepResponse> Steps { get; init; } = [];
     public IReadOnlyList<ManufacturingCustomFieldResponse> Fields { get; init; } = [];
+    public IReadOnlyList<ManufacturingPersonResponse> Designers { get; init; } = [];
+    public IReadOnlyList<ManufacturingPersonResponse> Craftsmen { get; init; } = [];
 }
 
 public sealed class ManufacturingProcessStepUpsertRequest

--- a/backend/Services/NoopCustomerManufacturingSqlService.cs
+++ b/backend/Services/NoopCustomerManufacturingSqlService.cs
@@ -51,6 +51,32 @@ public sealed class NoopCustomerManufacturingSqlService : ICustomerManufacturing
     public Task<bool> DeleteManufacturingProjectAsync(int projectId, CancellationToken cancellationToken = default)
         => Task.FromResult(false);
 
+    public Task<IReadOnlyList<ManufacturingPersonResponse>> GetManufacturingPeopleAsync(
+        string? role,
+        bool activeOnly,
+        CancellationToken cancellationToken = default)
+        => Task.FromResult<IReadOnlyList<ManufacturingPersonResponse>>([]);
+
+    public Task<ManufacturingPersonResponse> CreateManufacturingPersonAsync(
+        ManufacturingPersonUpsertRequest request,
+        CancellationToken cancellationToken = default)
+        => Task.FromException<ManufacturingPersonResponse>(new InvalidOperationException("SQL connection is not configured."));
+
+    public Task<ManufacturingPersonResponse?> UpdateManufacturingPersonAsync(
+        int personId,
+        ManufacturingPersonUpsertRequest request,
+        CancellationToken cancellationToken = default)
+        => Task.FromResult<ManufacturingPersonResponse?>(null);
+
+    public Task<bool> DeleteManufacturingPersonAsync(int personId, CancellationToken cancellationToken = default)
+        => Task.FromResult(false);
+
+    public Task<ManufacturingPersonProfileResponse?> GetManufacturingPersonProfileAsync(
+        int personId,
+        int limit,
+        CancellationToken cancellationToken = default)
+        => Task.FromResult<ManufacturingPersonProfileResponse?>(null);
+
     public Task<ManufacturingSettingsResponse> GetManufacturingSettingsAsync(CancellationToken cancellationToken = default)
         => Task.FromResult(new ManufacturingSettingsResponse
         {

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -200,6 +200,7 @@ export interface ManufacturingActivityLog {
   activityAtUtc: string
   craftsmanName: string | null
   notes: string | null
+  photos: string[]
 }
 
 export interface ManufacturingProjectSummary {
@@ -288,7 +289,32 @@ export interface ManufacturingProjectUpsertRequest {
   soldAt?: string | null
   gemstones?: ManufacturingGemstoneUpsertRequest[] | null
   activityNote?: string | null
+  activityPhotos?: string[] | null
   customFields?: Record<string, string | null> | null
+}
+
+export interface ManufacturingPerson {
+  id: number
+  role: 'designer' | 'craftsman'
+  name: string
+  email: string | null
+  phone: string | null
+  isActive: boolean
+  createdAtUtc: string
+  updatedAtUtc: string
+}
+
+export interface ManufacturingPersonUpsertRequest {
+  role: 'designer' | 'craftsman'
+  name: string
+  email?: string | null
+  phone?: string | null
+  isActive?: boolean
+}
+
+export interface ManufacturingPersonProfile {
+  person: ManufacturingPerson
+  projects: ManufacturingProjectSummary[]
 }
 
 export interface ManufacturingProcessStep {
@@ -314,6 +340,8 @@ export interface ManufacturingCustomField {
 export interface ManufacturingSettings {
   steps: ManufacturingProcessStep[]
   fields: ManufacturingCustomField[]
+  designers: ManufacturingPerson[]
+  craftsmen: ManufacturingPerson[]
 }
 
 export interface ManufacturingProcessStepUpsertRequest {

--- a/frontend/src/components/dashboard/SettingsPanel.tsx
+++ b/frontend/src/components/dashboard/SettingsPanel.tsx
@@ -1,6 +1,19 @@
-import { useEffect, useState } from 'react'
-import { getManufacturingSettings, updateManufacturingSettings } from '../../api/client'
-import type { ManufacturingCustomField, ManufacturingProcessStep } from '../../api/types'
+import { useEffect, useMemo, useState } from 'react'
+import { Eye, Plus, Save, Trash2, UserRound, Wrench, X } from 'lucide-react'
+import {
+  createManufacturingPerson,
+  deleteManufacturingPerson,
+  getManufacturingPersonProfile,
+  getManufacturingSettings,
+  updateManufacturingPerson,
+  updateManufacturingSettings
+} from '../../api/client'
+import type {
+  ManufacturingCustomField,
+  ManufacturingPerson,
+  ManufacturingPersonProfile,
+  ManufacturingProcessStep
+} from '../../api/types'
 import { useSession } from '../../app/useSession'
 
 function slugify(value: string): string {
@@ -12,14 +25,81 @@ function slugify(value: string): string {
 
 const FIELD_TYPES: ManufacturingCustomField['fieldType'][] = ['text', 'textarea', 'number', 'date', 'select']
 
+type WorkforceRole = 'designer' | 'craftsman'
+
+interface EditablePerson {
+  id: number
+  role: WorkforceRole
+  name: string
+  email: string
+  phone: string
+  isActive: boolean
+}
+
+function mapEditablePeople(role: WorkforceRole, items: ManufacturingPerson[]): EditablePerson[] {
+  return items
+    .filter(item => item.role === role)
+    .map(item => ({
+      id: item.id,
+      role,
+      name: item.name,
+      email: item.email ?? '',
+      phone: item.phone ?? '',
+      isActive: item.isActive
+    }))
+}
+
+function createDraftPerson(role: WorkforceRole): EditablePerson {
+  return {
+    id: -Date.now() - Math.floor(Math.random() * 1000),
+    role,
+    name: '',
+    email: '',
+    phone: '',
+    isActive: true
+  }
+}
+
+function formatDate(raw: string | null | undefined): string {
+  if (!raw) {
+    return '-'
+  }
+
+  const parsed = new Date(raw)
+  if (Number.isNaN(parsed.getTime())) {
+    return raw
+  }
+
+  return parsed.toLocaleDateString('en-GB', {
+    day: '2-digit',
+    month: 'short',
+    year: 'numeric'
+  })
+}
+
+function formatCurrency(value: number): string {
+  return new Intl.NumberFormat('th-TH', {
+    style: 'currency',
+    currency: 'THB',
+    maximumFractionDigits: 0
+  }).format(value)
+}
+
 export function SettingsPanel() {
   const { role } = useSession()
   const [steps, setSteps] = useState<ManufacturingProcessStep[]>([])
   const [fields, setFields] = useState<ManufacturingCustomField[]>([])
+  const [designers, setDesigners] = useState<EditablePerson[]>([])
+  const [craftsmen, setCraftsmen] = useState<EditablePerson[]>([])
+  const [deletedPersonIds, setDeletedPersonIds] = useState<number[]>([])
+
   const [isLoading, setIsLoading] = useState(true)
   const [isSaving, setIsSaving] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [success, setSuccess] = useState<string | null>(null)
+
+  const [profile, setProfile] = useState<ManufacturingPersonProfile | null>(null)
+  const [isLoadingProfile, setIsLoadingProfile] = useState(false)
 
   const isAdmin = role === 'admin'
 
@@ -31,6 +111,9 @@ export function SettingsPanel() {
       const settings = await getManufacturingSettings()
       setSteps(settings.steps)
       setFields(settings.fields)
+      setDesigners(mapEditablePeople('designer', settings.designers))
+      setCraftsmen(mapEditablePeople('craftsman', settings.craftsmen))
+      setDeletedPersonIds([])
     } catch {
       setError('Unable to load manufacturing settings.')
     } finally {
@@ -41,6 +124,13 @@ export function SettingsPanel() {
   useEffect(() => {
     void loadSettings()
   }, [])
+
+  const activeProfileRole = useMemo(() => {
+    if (!profile) {
+      return null
+    }
+    return profile.person.role
+  }, [profile])
 
   function addStep() {
     setSteps(current => [
@@ -80,6 +170,75 @@ export function SettingsPanel() {
     setFields(current => current.filter((_, currentIndex) => currentIndex !== index))
   }
 
+  function updatePerson(roleKey: WorkforceRole, index: number, patch: Partial<EditablePerson>) {
+    const setter = roleKey === 'designer' ? setDesigners : setCraftsmen
+    setter(current => current.map((item, itemIndex) => itemIndex === index ? { ...item, ...patch } : item))
+  }
+
+  function addPerson(roleKey: WorkforceRole) {
+    const setter = roleKey === 'designer' ? setDesigners : setCraftsmen
+    setter(current => [...current, createDraftPerson(roleKey)])
+  }
+
+  function removePerson(roleKey: WorkforceRole, index: number) {
+    const setter = roleKey === 'designer' ? setDesigners : setCraftsmen
+    setter(current => {
+      const person = current[index]
+      if (person && person.id > 0) {
+        setDeletedPersonIds(ids => Array.from(new Set([...ids, person.id])))
+      }
+      return current.filter((_, currentIndex) => currentIndex !== index)
+    })
+
+    if (profile && profile.person.id === (roleKey === 'designer' ? designers[index]?.id : craftsmen[index]?.id)) {
+      setProfile(null)
+    }
+  }
+
+  async function openProfile(person: EditablePerson) {
+    if (person.id <= 0) {
+      setError('Save this profile first, then you can open linked pieces.')
+      return
+    }
+
+    setIsLoadingProfile(true)
+    setError(null)
+    try {
+      const loaded = await getManufacturingPersonProfile(person.id)
+      setProfile(loaded)
+    } catch {
+      setError('Unable to load profile details.')
+    } finally {
+      setIsLoadingProfile(false)
+    }
+  }
+
+  async function syncPeople(roleKey: WorkforceRole, list: EditablePerson[]) {
+    for (const person of list) {
+      const normalizedName = person.name.trim()
+      if (!normalizedName) {
+        if (person.id > 0) {
+          throw new Error(`${roleKey === 'designer' ? 'Designer' : 'Craftsman'} name is required.`)
+        }
+        continue
+      }
+
+      const payload = {
+        role: roleKey,
+        name: normalizedName,
+        email: person.email.trim() || null,
+        phone: person.phone.trim() || null,
+        isActive: person.isActive
+      } as const
+
+      if (person.id > 0) {
+        await updateManufacturingPerson(person.id, payload)
+      } else {
+        await createManufacturingPerson(payload)
+      }
+    }
+  }
+
   async function saveSettings() {
     setIsSaving(true)
     setError(null)
@@ -106,12 +265,20 @@ export function SettingsPanel() {
         }))
       }
 
-      const updated = await updateManufacturingSettings(payload)
-      setSteps(updated.steps)
-      setFields(updated.fields)
+      await updateManufacturingSettings(payload)
+
+      for (const personId of deletedPersonIds) {
+        await deleteManufacturingPerson(personId)
+      }
+
+      await syncPeople('designer', designers)
+      await syncPeople('craftsman', craftsmen)
+
+      await loadSettings()
       setSuccess('Settings saved.')
-    } catch {
-      setError('Unable to save settings.')
+    } catch (caught) {
+      const message = caught instanceof Error ? caught.message : null
+      setError(message || 'Unable to save settings.')
     } finally {
       setIsSaving(false)
     }
@@ -136,195 +303,452 @@ export function SettingsPanel() {
   }
 
   return (
-    <section className="content-card">
-      <div className="card-head">
-        <div>
-          <h3>Production Settings</h3>
-          <p>Configure workflow steps and dynamic manufacturing fields.</p>
+    <div className={`settings-layout ${profile ? 'has-profile' : ''}`}>
+      <section className="content-card settings-dark-panel">
+        <div className="card-head settings-dark-headline">
+          <div>
+            <h3>Production Settings</h3>
+            <p>Configure production steps, workforce directory, and dynamic manufacturing fields.</p>
+          </div>
+          <button type="button" className="primary-btn" onClick={() => void saveSettings()} disabled={isSaving}>
+            <Save size={14} />
+            {isSaving ? 'Saving...' : 'Save Settings'}
+          </button>
         </div>
-        <button type="button" className="primary-btn" onClick={() => void saveSettings()} disabled={isSaving}>
-          {isSaving ? 'Saving...' : 'Save Settings'}
-        </button>
-      </div>
 
-      {error ? <p className="error-banner">{error}</p> : null}
-      {success ? <p className="panel-placeholder">{success}</p> : null}
+        {error ? <p className="error-banner">{error}</p> : null}
+        {success ? <p className="panel-placeholder">{success}</p> : null}
 
-      <div className="usage-lines">
-        <div className="card-head">
-          <h4>Production Steps</h4>
-          <button type="button" className="secondary-btn" onClick={addStep}>Add Step</button>
-        </div>
-        <div className="usage-table-wrap">
-          <table className="usage-table">
-            <thead>
-              <tr>
-                <th>Step Key</th>
-                <th>Label</th>
-                <th>Require Photo</th>
-                <th>Require Comment</th>
-                <th>Active</th>
-                <th>Action</th>
-              </tr>
-            </thead>
-            <tbody>
-              {steps.map((step, index) => (
-                <tr key={`${step.stepKey || 'new'}-${index}`}>
-                  <td>
-                    <input
-                      value={step.stepKey}
-                      onChange={event => {
-                        const value = event.target.value
-                        setSteps(current => current.map((item, itemIndex) => itemIndex === index ? { ...item, stepKey: value } : item))
-                      }}
-                    />
-                  </td>
-                  <td>
-                    <input
-                      value={step.label}
-                      onChange={event => {
-                        const value = event.target.value
-                        setSteps(current => current.map((item, itemIndex) => itemIndex === index ? { ...item, label: value } : item))
-                      }}
-                    />
-                  </td>
-                  <td>
-                    <input
-                      type="checkbox"
-                      checked={step.requirePhoto}
-                      onChange={event => {
-                        const checked = event.target.checked
-                        setSteps(current => current.map((item, itemIndex) => itemIndex === index ? { ...item, requirePhoto: checked } : item))
-                      }}
-                    />
-                  </td>
-                  <td>
-                    <input
-                      type="checkbox"
-                      checked={step.requireComment}
-                      onChange={event => {
-                        const checked = event.target.checked
-                        setSteps(current => current.map((item, itemIndex) => itemIndex === index ? { ...item, requireComment: checked } : item))
-                      }}
-                    />
-                  </td>
-                  <td>
-                    <input
-                      type="checkbox"
-                      checked={step.isActive}
-                      onChange={event => {
-                        const checked = event.target.checked
-                        setSteps(current => current.map((item, itemIndex) => itemIndex === index ? { ...item, isActive: checked } : item))
-                      }}
-                    />
-                  </td>
-                  <td>
-                    <button type="button" className="secondary-btn" onClick={() => removeStep(index)}>Remove</button>
-                  </td>
+        <div className="settings-dark-block">
+          <div className="settings-dark-section-head">
+            <div>
+              <h4>Production Steps</h4>
+              <p>Define each manufacturing stage and required evidence.</p>
+            </div>
+            <button type="button" className="secondary-btn" onClick={addStep}>
+              <Plus size={14} />
+              Add Step
+            </button>
+          </div>
+
+          <div className="usage-table-wrap settings-dark-table-wrap">
+            <table className="usage-table settings-dark-table">
+              <thead>
+                <tr>
+                  <th>Step Key</th>
+                  <th>Label</th>
+                  <th>Photo</th>
+                  <th>Comment</th>
+                  <th>Active</th>
+                  <th>Action</th>
                 </tr>
-              ))}
-            </tbody>
-          </table>
+              </thead>
+              <tbody>
+                {steps.map((step, index) => (
+                  <tr key={`${step.stepKey || 'new'}-${index}`}>
+                    <td>
+                      <input
+                        value={step.stepKey}
+                        onChange={event => {
+                          const value = event.target.value
+                          setSteps(current => current.map((item, itemIndex) => itemIndex === index ? { ...item, stepKey: value } : item))
+                        }}
+                      />
+                    </td>
+                    <td>
+                      <input
+                        value={step.label}
+                        onChange={event => {
+                          const value = event.target.value
+                          setSteps(current => current.map((item, itemIndex) => itemIndex === index ? { ...item, label: value } : item))
+                        }}
+                      />
+                    </td>
+                    <td>
+                      <input
+                        type="checkbox"
+                        checked={step.requirePhoto}
+                        onChange={event => {
+                          const checked = event.target.checked
+                          setSteps(current => current.map((item, itemIndex) => itemIndex === index ? { ...item, requirePhoto: checked } : item))
+                        }}
+                      />
+                    </td>
+                    <td>
+                      <input
+                        type="checkbox"
+                        checked={step.requireComment}
+                        onChange={event => {
+                          const checked = event.target.checked
+                          setSteps(current => current.map((item, itemIndex) => itemIndex === index ? { ...item, requireComment: checked } : item))
+                        }}
+                      />
+                    </td>
+                    <td>
+                      <input
+                        type="checkbox"
+                        checked={step.isActive}
+                        onChange={event => {
+                          const checked = event.target.checked
+                          setSteps(current => current.map((item, itemIndex) => itemIndex === index ? { ...item, isActive: checked } : item))
+                        }}
+                      />
+                    </td>
+                    <td>
+                      <button type="button" className="icon-btn" onClick={() => removeStep(index)} aria-label="Remove step" title="Remove step">
+                        <Trash2 size={16} />
+                      </button>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
         </div>
-      </div>
 
-      <div className="usage-lines">
-        <div className="card-head">
-          <h4>Manufacturing Fields</h4>
-          <button type="button" className="secondary-btn" onClick={addField}>Add Field</button>
-        </div>
-        <div className="usage-table-wrap">
-          <table className="usage-table">
-            <thead>
-              <tr>
-                <th>Key</th>
-                <th>Label</th>
-                <th>Type</th>
-                <th>Required</th>
-                <th>Active</th>
-                <th>Options (select)</th>
-                <th>Action</th>
-              </tr>
-            </thead>
-            <tbody>
-              {fields.map((field, index) => (
-                <tr key={`${field.fieldKey || 'field'}-${index}`}>
-                  <td>
-                    <input
-                      value={field.fieldKey}
-                      onChange={event => {
-                        const value = event.target.value
-                        setFields(current => current.map((item, itemIndex) => itemIndex === index ? { ...item, fieldKey: value } : item))
-                      }}
-                    />
-                  </td>
-                  <td>
-                    <input
-                      value={field.label}
-                      onChange={event => {
-                        const value = event.target.value
-                        setFields(current => current.map((item, itemIndex) => itemIndex === index ? { ...item, label: value } : item))
-                      }}
-                    />
-                  </td>
-                  <td>
-                    <select
-                      value={field.fieldType}
-                      onChange={event => {
-                        const value = event.target.value as ManufacturingCustomField['fieldType']
-                        setFields(current => current.map((item, itemIndex) => itemIndex === index ? { ...item, fieldType: value } : item))
-                      }}
-                    >
-                      {FIELD_TYPES.map(type => (
-                        <option key={type} value={type}>{type}</option>
-                      ))}
-                    </select>
-                  </td>
-                  <td>
-                    <input
-                      type="checkbox"
-                      checked={field.isRequired}
-                      onChange={event => {
-                        const checked = event.target.checked
-                        setFields(current => current.map((item, itemIndex) => itemIndex === index ? { ...item, isRequired: checked } : item))
-                      }}
-                    />
-                  </td>
-                  <td>
-                    <input
-                      type="checkbox"
-                      checked={field.isActive}
-                      onChange={event => {
-                        const checked = event.target.checked
-                        setFields(current => current.map((item, itemIndex) => itemIndex === index ? { ...item, isActive: checked } : item))
-                      }}
-                    />
-                  </td>
-                  <td>
-                    <input
-                      value={field.options.join(', ')}
-                      placeholder="A, B, C"
-                      onChange={event => {
-                        const value = event.target.value
-                        setFields(current => current.map((item, itemIndex) => itemIndex === index ? {
-                          ...item,
-                          options: value
-                            .split(',')
-                            .map(option => option.trim())
-                            .filter(option => option.length > 0)
-                        } : item))
-                      }}
-                    />
-                  </td>
-                  <td>
-                    <button type="button" className="secondary-btn" onClick={() => removeField(index)}>Remove</button>
-                  </td>
+        <div className="settings-dark-block">
+          <div className="settings-dark-section-head">
+            <div>
+              <h4>
+                <UserRound size={16} />
+                Designers
+              </h4>
+              <p>Add and manage designers for manufacturing projects.</p>
+            </div>
+            <button type="button" className="secondary-btn" onClick={() => addPerson('designer')}>
+              <Plus size={14} />
+              Add Designer
+            </button>
+          </div>
+
+          <div className="usage-table-wrap settings-dark-table-wrap">
+            <table className="usage-table settings-dark-table workforce-table">
+              <thead>
+                <tr>
+                  <th>Name</th>
+                  <th>Email</th>
+                  <th>Phone</th>
+                  <th>Active</th>
+                  <th>Action</th>
                 </tr>
-              ))}
-            </tbody>
-          </table>
+              </thead>
+              <tbody>
+                {designers.map((person, index) => (
+                  <tr key={`${person.id}-${index}`}>
+                    <td>
+                      <input
+                        value={person.name}
+                        placeholder="Designer name"
+                        onChange={event => updatePerson('designer', index, { name: event.target.value })}
+                      />
+                    </td>
+                    <td>
+                      <input
+                        value={person.email}
+                        placeholder="designer@company.com"
+                        onChange={event => updatePerson('designer', index, { email: event.target.value })}
+                      />
+                    </td>
+                    <td>
+                      <input
+                        value={person.phone}
+                        placeholder="+66..."
+                        onChange={event => updatePerson('designer', index, { phone: event.target.value })}
+                      />
+                    </td>
+                    <td>
+                      <input
+                        type="checkbox"
+                        checked={person.isActive}
+                        onChange={event => updatePerson('designer', index, { isActive: event.target.checked })}
+                      />
+                    </td>
+                    <td>
+                      <div className="workforce-actions">
+                        <button
+                          type="button"
+                          className="icon-btn"
+                          onClick={() => void openProfile(person)}
+                          disabled={person.id <= 0}
+                          aria-label="View profile"
+                          title="View profile"
+                        >
+                          <Eye size={16} />
+                        </button>
+                        <button
+                          type="button"
+                          className="icon-btn"
+                          onClick={() => removePerson('designer', index)}
+                          aria-label="Remove designer"
+                          title="Remove designer"
+                        >
+                          <Trash2 size={16} />
+                        </button>
+                      </div>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
         </div>
-      </div>
-    </section>
+
+        <div className="settings-dark-block">
+          <div className="settings-dark-section-head">
+            <div>
+              <h4>
+                <Wrench size={16} />
+                Craftsmen
+              </h4>
+              <p>Manage craftsman contacts used in project details and workflow logs.</p>
+            </div>
+            <button type="button" className="secondary-btn" onClick={() => addPerson('craftsman')}>
+              <Plus size={14} />
+              Add Craftsman
+            </button>
+          </div>
+
+          <div className="usage-table-wrap settings-dark-table-wrap">
+            <table className="usage-table settings-dark-table workforce-table">
+              <thead>
+                <tr>
+                  <th>Name</th>
+                  <th>Email</th>
+                  <th>Phone</th>
+                  <th>Active</th>
+                  <th>Action</th>
+                </tr>
+              </thead>
+              <tbody>
+                {craftsmen.map((person, index) => (
+                  <tr key={`${person.id}-${index}`}>
+                    <td>
+                      <input
+                        value={person.name}
+                        placeholder="Craftsman name"
+                        onChange={event => updatePerson('craftsman', index, { name: event.target.value })}
+                      />
+                    </td>
+                    <td>
+                      <input
+                        value={person.email}
+                        placeholder="craftsman@company.com"
+                        onChange={event => updatePerson('craftsman', index, { email: event.target.value })}
+                      />
+                    </td>
+                    <td>
+                      <input
+                        value={person.phone}
+                        placeholder="+66..."
+                        onChange={event => updatePerson('craftsman', index, { phone: event.target.value })}
+                      />
+                    </td>
+                    <td>
+                      <input
+                        type="checkbox"
+                        checked={person.isActive}
+                        onChange={event => updatePerson('craftsman', index, { isActive: event.target.checked })}
+                      />
+                    </td>
+                    <td>
+                      <div className="workforce-actions">
+                        <button
+                          type="button"
+                          className="icon-btn"
+                          onClick={() => void openProfile(person)}
+                          disabled={person.id <= 0}
+                          aria-label="View profile"
+                          title="View profile"
+                        >
+                          <Eye size={16} />
+                        </button>
+                        <button
+                          type="button"
+                          className="icon-btn"
+                          onClick={() => removePerson('craftsman', index)}
+                          aria-label="Remove craftsman"
+                          title="Remove craftsman"
+                        >
+                          <Trash2 size={16} />
+                        </button>
+                      </div>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+
+        <div className="settings-dark-block">
+          <div className="settings-dark-section-head">
+            <div>
+              <h4>Manufacturing Fields</h4>
+              <p>Manage extra dynamic fields for project forms.</p>
+            </div>
+            <button type="button" className="secondary-btn" onClick={addField}>
+              <Plus size={14} />
+              Add Field
+            </button>
+          </div>
+
+          <div className="usage-table-wrap settings-dark-table-wrap">
+            <table className="usage-table settings-dark-table">
+              <thead>
+                <tr>
+                  <th>Key</th>
+                  <th>Label</th>
+                  <th>Type</th>
+                  <th>Required</th>
+                  <th>Active</th>
+                  <th>Options</th>
+                  <th>Action</th>
+                </tr>
+              </thead>
+              <tbody>
+                {fields.map((field, index) => (
+                  <tr key={`${field.fieldKey || 'field'}-${index}`}>
+                    <td>
+                      <input
+                        value={field.fieldKey}
+                        onChange={event => {
+                          const value = event.target.value
+                          setFields(current => current.map((item, itemIndex) => itemIndex === index ? { ...item, fieldKey: value } : item))
+                        }}
+                      />
+                    </td>
+                    <td>
+                      <input
+                        value={field.label}
+                        onChange={event => {
+                          const value = event.target.value
+                          setFields(current => current.map((item, itemIndex) => itemIndex === index ? { ...item, label: value } : item))
+                        }}
+                      />
+                    </td>
+                    <td>
+                      <select
+                        value={field.fieldType}
+                        onChange={event => {
+                          const value = event.target.value as ManufacturingCustomField['fieldType']
+                          setFields(current => current.map((item, itemIndex) => itemIndex === index ? { ...item, fieldType: value } : item))
+                        }}
+                      >
+                        {FIELD_TYPES.map(type => (
+                          <option key={type} value={type}>{type}</option>
+                        ))}
+                      </select>
+                    </td>
+                    <td>
+                      <input
+                        type="checkbox"
+                        checked={field.isRequired}
+                        onChange={event => {
+                          const checked = event.target.checked
+                          setFields(current => current.map((item, itemIndex) => itemIndex === index ? { ...item, isRequired: checked } : item))
+                        }}
+                      />
+                    </td>
+                    <td>
+                      <input
+                        type="checkbox"
+                        checked={field.isActive}
+                        onChange={event => {
+                          const checked = event.target.checked
+                          setFields(current => current.map((item, itemIndex) => itemIndex === index ? { ...item, isActive: checked } : item))
+                        }}
+                      />
+                    </td>
+                    <td>
+                      <input
+                        value={field.options.join(', ')}
+                        placeholder="A, B, C"
+                        onChange={event => {
+                          const value = event.target.value
+                          setFields(current => current.map((item, itemIndex) => itemIndex === index ? {
+                            ...item,
+                            options: value
+                              .split(',')
+                              .map(option => option.trim())
+                              .filter(option => option.length > 0)
+                          } : item))
+                        }}
+                      />
+                    </td>
+                    <td>
+                      <button type="button" className="icon-btn" onClick={() => removeField(index)} aria-label="Remove field" title="Remove field">
+                        <Trash2 size={16} />
+                      </button>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </section>
+
+      {profile ? (
+        <aside className="detail-side-panel settings-profile-panel">
+          <div className="drawer-head">
+            <div>
+              <h3>{activeProfileRole === 'designer' ? 'Designer Profile' : 'Craftsman Profile'}</h3>
+              <p className="panel-placeholder">Linked pieces and production history.</p>
+            </div>
+            <button type="button" className="icon-btn" onClick={() => setProfile(null)} aria-label="Close profile" title="Close profile">
+              <X size={18} />
+            </button>
+          </div>
+
+          {isLoadingProfile ? (
+            <p className="panel-placeholder">Loading profile...</p>
+          ) : (
+            <>
+              <div className="usage-lines">
+                <h4>{profile.person.name}</h4>
+                <p>{profile.person.email ?? '-'}</p>
+                <p>{profile.person.phone ?? '-'}</p>
+                <p>
+                  Joined
+                  {' '}
+                  {formatDate(profile.person.createdAtUtc)}
+                </p>
+              </div>
+
+              <div className="usage-lines">
+                <h4>Pieces ({profile.projects.length})</h4>
+                {profile.projects.length === 0 ? (
+                  <p className="panel-placeholder">No linked manufacturing projects yet.</p>
+                ) : (
+                  <div className="activity-list">
+                    {profile.projects.map(project => (
+                      <article key={project.id}>
+                        <p>
+                          <strong>{project.manufacturingCode}</strong>
+                          {' • '}
+                          {project.pieceName}
+                        </p>
+                        <p>
+                          {project.status.replace(/_/g, ' ')}
+                          {' • '}
+                          {formatDate(project.updatedAtUtc)}
+                        </p>
+                        <p>
+                          Cost
+                          {' '}
+                          {formatCurrency(project.totalCost)}
+                          {' • Sale '}
+                          {formatCurrency(project.sellingPrice)}
+                        </p>
+                      </article>
+                    ))}
+                  </div>
+                )}
+              </div>
+            </>
+          )}
+        </aside>
+      ) : null}
+    </div>
   )
 }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -890,6 +890,224 @@ a:focus-visible {
   background: #fffdf9;
 }
 
+.step-evidence-label {
+  display: grid;
+  gap: 0.4rem;
+  margin-top: 0.65rem;
+  font-size: 0.84rem;
+  color: var(--ink-700);
+}
+
+.step-evidence-label textarea,
+.step-evidence-label input[type='file'] {
+  border: 1px solid var(--line-strong);
+  border-radius: 11px;
+  padding: 0.62rem 0.7rem;
+  background: #fffdf9;
+}
+
+.activity-photo-grid {
+  margin-top: 0.6rem;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(110px, 1fr));
+  gap: 0.52rem;
+}
+
+.activity-photo-item,
+.pending-photo-card {
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  background: #fff;
+  overflow: hidden;
+}
+
+.activity-photo-item img,
+.pending-photo-card img {
+  display: block;
+  width: 100%;
+  height: 88px;
+  object-fit: cover;
+}
+
+.pending-photo-card {
+  padding: 0.4rem;
+  display: grid;
+  gap: 0.35rem;
+}
+
+.pending-photo-card p {
+  margin: 0;
+  font-size: 0.75rem;
+  color: var(--ink-700);
+  line-height: 1.2;
+  overflow-wrap: anywhere;
+}
+
+.settings-layout {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  gap: 0.88rem;
+}
+
+.settings-layout.has-profile {
+  grid-template-columns: minmax(0, 1fr) 370px;
+}
+
+.settings-dark-panel {
+  background: radial-gradient(circle at top right, rgba(216, 138, 0, 0.12), transparent 44%), #07090d;
+  border-color: #181f2a;
+  color: #f8fafc;
+}
+
+.settings-dark-panel .panel-placeholder {
+  color: #8ea3be;
+}
+
+.settings-dark-panel .error-banner {
+  background: rgba(127, 29, 29, 0.2);
+  border-color: rgba(252, 165, 165, 0.28);
+  color: #fecaca;
+}
+
+.settings-dark-headline p {
+  color: #8ea3be;
+}
+
+.settings-dark-block {
+  margin-top: 1rem;
+  border: 1px solid #182132;
+  border-radius: 16px;
+  background: rgba(8, 11, 17, 0.86);
+  padding: 1rem;
+}
+
+.settings-dark-section-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 0.8rem;
+  margin-bottom: 0.75rem;
+}
+
+.settings-dark-section-head h4 {
+  margin: 0;
+  font-size: 1.1rem;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.44rem;
+}
+
+.settings-dark-section-head p {
+  margin: 0.28rem 0 0;
+  color: #8ea3be;
+  font-size: 0.84rem;
+}
+
+.settings-dark-table-wrap {
+  border-color: #1b2332;
+  background: #070b12;
+}
+
+.settings-dark-table th {
+  background: #0d131d;
+  color: #c6d2e3;
+  border-bottom-color: #1f2c3f;
+}
+
+.settings-dark-table td {
+  border-bottom-color: #172234;
+  color: #e2e8f0;
+}
+
+.settings-dark-table tbody tr {
+  cursor: default;
+}
+
+.settings-dark-table tbody tr:hover {
+  background: #0c1320;
+}
+
+.settings-dark-table input,
+.settings-dark-table select {
+  width: 100%;
+  border: 1px solid #263247;
+  border-radius: 10px;
+  padding: 0.52rem 0.6rem;
+  background: #0a111b;
+  color: #f8fafc;
+}
+
+.settings-dark-table input[type='checkbox'] {
+  width: 18px;
+  height: 18px;
+  accent-color: #18c964;
+  border-radius: 4px;
+  padding: 0;
+}
+
+.settings-dark-table input::placeholder {
+  color: #6f819b;
+}
+
+.workforce-table td:last-child {
+  width: 130px;
+}
+
+.workforce-actions {
+  display: flex;
+  gap: 0.42rem;
+}
+
+.settings-dark-panel .primary-btn {
+  background: linear-gradient(180deg, #f3bb39, #e49a00);
+  color: #101623;
+  border-color: #e7ad34;
+  box-shadow: 0 10px 22px rgba(228, 154, 0, 0.34);
+}
+
+.settings-dark-panel .secondary-btn {
+  background: rgba(243, 187, 57, 0.1);
+  border-color: rgba(243, 187, 57, 0.4);
+  color: #ffdb89;
+}
+
+.settings-dark-panel .secondary-btn:hover {
+  background: rgba(243, 187, 57, 0.18);
+  border-color: rgba(243, 187, 57, 0.68);
+}
+
+.settings-dark-panel .icon-btn {
+  border-color: #32415a;
+  background: #0d1522;
+  color: #c6d2e3;
+}
+
+.settings-dark-panel .icon-btn:hover {
+  background: #162237;
+  border-color: #4b5f81;
+  color: #f8fafc;
+}
+
+.settings-dark-panel .icon-btn:disabled {
+  opacity: 0.45;
+  cursor: default;
+}
+
+.settings-profile-panel {
+  background: #0a101a;
+  border-color: #1d2839;
+  color: #f8fafc;
+}
+
+.settings-profile-panel .panel-placeholder {
+  color: #8ea3be;
+}
+
+.settings-profile-panel .activity-list article {
+  border-color: #263247;
+  background: #111926;
+}
+
 .customer-name-cell {
   display: inline-flex;
   align-items: center;
@@ -1084,6 +1302,10 @@ a:focus-visible {
   }
 
   .content-split.has-detail {
+    grid-template-columns: 1fr;
+  }
+
+  .settings-layout.has-profile {
     grid-template-columns: 1fr;
   }
 

--- a/migrations/005_manufacturing_people_activity_photos.sql
+++ b/migrations/005_manufacturing_people_activity_photos.sql
@@ -1,0 +1,91 @@
+-- Manufacturing workforce registry + activity photo evidence support.
+
+IF OBJECT_ID('dbo.manufacturing_people', 'U') IS NULL
+BEGIN
+    CREATE TABLE dbo.manufacturing_people (
+        id INT IDENTITY(1,1) NOT NULL PRIMARY KEY,
+        role NVARCHAR(32) NOT NULL,
+        name NVARCHAR(180) NOT NULL,
+        email NVARCHAR(255) NULL,
+        phone NVARCHAR(64) NULL,
+        is_active BIT NOT NULL DEFAULT 1,
+        created_at_utc DATETIME2 NOT NULL DEFAULT SYSUTCDATETIME(),
+        updated_at_utc DATETIME2 NOT NULL DEFAULT SYSUTCDATETIME(),
+        CONSTRAINT CK_manufacturing_people_role CHECK (role IN ('designer', 'craftsman'))
+    );
+END
+GO
+
+IF NOT EXISTS (
+    SELECT 1
+    FROM sys.indexes
+    WHERE object_id = OBJECT_ID('dbo.manufacturing_people')
+      AND name = 'UX_manufacturing_people_role_name'
+)
+BEGIN
+    CREATE UNIQUE INDEX UX_manufacturing_people_role_name
+        ON dbo.manufacturing_people(role, name);
+END
+GO
+
+IF NOT EXISTS (
+    SELECT 1
+    FROM sys.indexes
+    WHERE object_id = OBJECT_ID('dbo.manufacturing_people')
+      AND name = 'IX_manufacturing_people_role_active'
+)
+BEGIN
+    CREATE INDEX IX_manufacturing_people_role_active
+        ON dbo.manufacturing_people(role, is_active, name);
+END
+GO
+
+IF COL_LENGTH('dbo.manufacturing_activity_log', 'photos_json') IS NULL
+BEGIN
+    ALTER TABLE dbo.manufacturing_activity_log
+    ADD photos_json NVARCHAR(MAX) NULL;
+END
+GO
+
+;WITH DistinctDesigners AS (
+    SELECT DISTINCT
+        LTRIM(RTRIM(mp.designer_name)) AS person_name
+    FROM dbo.manufacturing_projects mp
+    WHERE mp.designer_name IS NOT NULL
+      AND LTRIM(RTRIM(mp.designer_name)) <> ''
+)
+INSERT INTO dbo.manufacturing_people (role, name, is_active, updated_at_utc)
+SELECT
+    'designer' AS role,
+    d.person_name,
+    1 AS is_active,
+    SYSUTCDATETIME() AS updated_at_utc
+FROM DistinctDesigners d
+WHERE NOT EXISTS (
+    SELECT 1
+    FROM dbo.manufacturing_people p
+    WHERE p.role = 'designer'
+      AND p.name = d.person_name
+);
+
+;WITH DistinctCraftsmen AS (
+    SELECT DISTINCT
+        LTRIM(RTRIM(mp.craftsman_name)) AS person_name
+    FROM dbo.manufacturing_projects mp
+    WHERE mp.craftsman_name IS NOT NULL
+      AND LTRIM(RTRIM(mp.craftsman_name)) <> ''
+)
+INSERT INTO dbo.manufacturing_people (role, name, is_active, updated_at_utc)
+SELECT
+    'craftsman' AS role,
+    c.person_name,
+    1 AS is_active,
+    SYSUTCDATETIME() AS updated_at_utc
+FROM DistinctCraftsmen c
+WHERE NOT EXISTS (
+    SELECT 1
+    FROM dbo.manufacturing_people p
+    WHERE p.role = 'craftsman'
+      AND p.name = c.person_name
+);
+GO


### PR DESCRIPTION
Closes #38

## What changed
- Added manufacturing workforce registry API (`/manufacturing/people`) with admin create/update/delete and profile drill-down.
- Extended manufacturing settings payload to include active designers/craftsmen.
- Added per-activity photo support in manufacturing activity logs and status updates (`activityPhotos`).
- Added migration `migrations/005_manufacturing_people_activity_photos.sql` to create `manufacturing_people`, add `photos_json`, and backfill existing names.
- Redesigned settings UI to match the production-style dark reference and added separate designer/craftsman tables with profile panel.
- Updated manufacturing create/edit forms to use designer/craftsman dropdown suggestions from registry.
- Added step evidence UX in manufacturing detail: comment + image upload with requirement-aware validation.

## Validation
- `dotnet build backend/backend.csproj`
- `npm run build` (frontend; Vite warns local Node 20.16.0 < 20.19 requirement but build succeeds)
- `API_BASE_URL='https://houseofrojanatorn-g8exadena3btbea7.southeastasia-01.azurewebsites.net/api' SMOKE_ADMIN_EMAIL='admin@houseofrojanatorn.local' SMOKE_ADMIN_PASSWORD='Admin!23456' bash tools/validation/run_api_smoke.sh`
- `dotnet run --project tools/db/SqlRunner -f net10.0 -- --file migrations/005_manufacturing_people_activity_photos.sql`
