### PR TITLE
Tiered settings control center + compact light UI tuning

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -53,6 +53,10 @@ textarea {
   color: inherit;
 }
 
+html {
+  font-size: 15px;
+}
+
 button:focus-visible,
 input:focus-visible,
 select:focus-visible,
@@ -65,7 +69,7 @@ a:focus-visible {
 .primary-btn,
 .secondary-btn {
   border-radius: 999px;
-  padding: 0.62rem 1.05rem;
+  padding: 0.52rem 0.9rem;
   border: 1px solid transparent;
   cursor: pointer;
   transition: background-color 0.18s ease, border-color 0.18s ease, box-shadow 0.18s ease, transform 0.18s ease;
@@ -76,6 +80,7 @@ a:focus-visible {
   text-decoration: none;
   white-space: nowrap;
   font-weight: 650;
+  font-size: 0.88rem;
 }
 
 .primary-btn {
@@ -108,8 +113,8 @@ a:focus-visible {
 }
 
 .icon-btn {
-  width: 38px;
-  height: 38px;
+  width: 34px;
+  height: 34px;
   border-radius: 999px;
   border: 1px solid #e0c995;
   background: #fff;
@@ -425,7 +430,7 @@ a:focus-visible {
 }
 
 .dashboard-main {
-  padding: 1.7rem 1.8rem;
+  padding: 1.45rem 1.6rem;
   display: grid;
   gap: 1rem;
 }
@@ -501,7 +506,7 @@ a:focus-visible {
 
 .card-head h3 {
   margin: 0;
-  font-size: 1.7rem;
+  font-size: 1.5rem;
   letter-spacing: -0.02em;
 }
 
@@ -630,7 +635,7 @@ a:focus-visible {
 .usage-table th {
   text-align: left;
   font-weight: 650;
-  font-size: 0.85rem;
+  font-size: 0.8rem;
   color: var(--ink-700);
   border-bottom: 1px solid var(--line);
   background: #f8f4ed;
@@ -639,8 +644,8 @@ a:focus-visible {
 
 .usage-table td {
   border-bottom: 1px solid #f3ece2;
-  padding: 1.02rem 0.88rem;
-  font-size: 0.93rem;
+  padding: 0.85rem 0.8rem;
+  font-size: 0.88rem;
   vertical-align: middle;
 }
 
@@ -943,110 +948,154 @@ a:focus-visible {
   overflow-wrap: anywhere;
 }
 
-.settings-layout {
+.settings-tier-layout {
   display: grid;
-  grid-template-columns: minmax(0, 1fr);
+  grid-template-columns: 290px minmax(0, 1fr);
   gap: 0.88rem;
+  align-items: start;
 }
 
-.settings-layout.has-profile {
-  grid-template-columns: minmax(0, 1fr) 370px;
+.settings-tier-layout.has-profile {
+  grid-template-columns: 290px minmax(0, 1fr) 350px;
 }
 
-.settings-dark-panel {
-  background: radial-gradient(circle at top right, rgba(216, 138, 0, 0.12), transparent 44%), #07090d;
-  border-color: #181f2a;
-  color: #f8fafc;
-}
-
-.settings-dark-panel .panel-placeholder {
-  color: #8ea3be;
-}
-
-.settings-dark-panel .error-banner {
-  background: rgba(127, 29, 29, 0.2);
-  border-color: rgba(252, 165, 165, 0.28);
-  color: #fecaca;
-}
-
-.settings-dark-headline p {
-  color: #8ea3be;
-}
-
-.settings-dark-block {
-  margin-top: 1rem;
-  border: 1px solid #182132;
-  border-radius: 16px;
-  background: rgba(8, 11, 17, 0.86);
+.settings-tier-nav {
+  position: sticky;
+  top: 1rem;
   padding: 1rem;
 }
 
-.settings-dark-section-head {
-  display: flex;
-  align-items: flex-start;
-  justify-content: space-between;
-  gap: 0.8rem;
-  margin-bottom: 0.75rem;
+.settings-tier-kicker {
+  margin: 0;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--ink-700);
+  font-size: 0.72rem;
+  font-weight: 700;
 }
 
-.settings-dark-section-head h4 {
+.settings-tier-nav h3 {
+  margin: 0.5rem 0 0;
+  font-size: 1.7rem;
+}
+
+.settings-tier-group {
+  margin-top: 1.15rem;
+  display: grid;
+  gap: 0.38rem;
+}
+
+.settings-tier-group p {
   margin: 0;
-  font-size: 1.1rem;
+  color: var(--ink-700);
+  font-size: 0.78rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  font-weight: 700;
+}
+
+.settings-tier-group button {
+  border: 1px solid transparent;
+  border-radius: 12px;
+  background: transparent;
+  color: var(--ink-900);
+  text-align: left;
   display: inline-flex;
   align-items: center;
-  gap: 0.44rem;
+  gap: 0.48rem;
+  padding: 0.52rem 0.58rem;
+  font-weight: 600;
+  cursor: pointer;
+  font-size: 0.9rem;
 }
 
-.settings-dark-section-head p {
-  margin: 0.28rem 0 0;
-  color: #8ea3be;
-  font-size: 0.84rem;
+.settings-tier-group button:hover {
+  border-color: var(--line);
+  background: #fffdf8;
 }
 
-.settings-dark-table-wrap {
-  border-color: #1b2332;
-  background: #070b12;
+.settings-tier-group button.active {
+  border-color: #dbbc82;
+  background: #fff6e8;
+  color: var(--accent-700);
 }
 
-.settings-dark-table th {
-  background: #0d131d;
-  color: #c6d2e3;
-  border-bottom-color: #1f2c3f;
+.settings-tier-main {
+  min-height: calc(100vh - 200px);
 }
 
-.settings-dark-table td {
-  border-bottom-color: #172234;
-  color: #e2e8f0;
+.settings-subhead {
+  margin-top: 0.4rem;
+  margin-bottom: 0.9rem;
 }
 
-.settings-dark-table tbody tr {
-  cursor: default;
+.settings-subhead h4 {
+  margin: 0;
+  font-size: 1.1rem;
 }
 
-.settings-dark-table tbody tr:hover {
-  background: #0c1320;
+.settings-inline-form {
+  margin-top: 0;
 }
 
-.settings-dark-table input,
-.settings-dark-table select {
-  width: 100%;
-  border: 1px solid #263247;
-  border-radius: 10px;
-  padding: 0.52rem 0.6rem;
-  background: #0a111b;
-  color: #f8fafc;
+.settings-profile-content {
+  display: grid;
+  grid-template-columns: 300px minmax(0, 1fr);
+  gap: 0.8rem;
 }
 
-.settings-dark-table input[type='checkbox'] {
-  width: 18px;
-  height: 18px;
-  accent-color: #18c964;
-  border-radius: 4px;
-  padding: 0;
+.settings-profile-card,
+.settings-profile-form-card {
+  border: 1px solid var(--line);
+  border-radius: 14px;
+  background: #fff;
+  padding: 0.9rem;
 }
 
-.settings-dark-table input::placeholder {
-  color: #6f819b;
+.settings-profile-card h4,
+.settings-profile-form-card h4 {
+  margin: 0;
+  font-size: 1.25rem;
+}
+
+.settings-profile-avatar {
+  margin-top: 1rem;
+  width: 76px;
+  height: 76px;
+  border-radius: 999px;
+  background: #f6ebd8;
+  border: 1px solid #e5c894;
+  color: var(--accent-700);
+  display: inline-grid;
+  place-items: center;
+  font-weight: 700;
+  font-size: 1.5rem;
+}
+
+.settings-profile-name {
+  margin: 0.7rem 0 0.12rem;
+  font-weight: 700;
+  font-size: 1rem;
+}
+
+.settings-profile-meta {
+  margin: 1rem 0 0;
+  display: grid;
+  gap: 0.65rem;
+}
+
+.settings-profile-meta dt {
+  color: var(--ink-700);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 0.72rem;
+  margin-bottom: 0.16rem;
+  font-weight: 650;
+}
+
+.settings-profile-meta dd {
+  margin: 0;
+  font-size: 0.9rem;
 }
 
 .workforce-table td:last-child {
@@ -1058,54 +1107,15 @@ a:focus-visible {
   gap: 0.42rem;
 }
 
-.settings-dark-panel .primary-btn {
-  background: linear-gradient(180deg, #f3bb39, #e49a00);
-  color: #101623;
-  border-color: #e7ad34;
-  box-shadow: 0 10px 22px rgba(228, 154, 0, 0.34);
-}
-
-.settings-dark-panel .secondary-btn {
-  background: rgba(243, 187, 57, 0.1);
-  border-color: rgba(243, 187, 57, 0.4);
-  color: #ffdb89;
-}
-
-.settings-dark-panel .secondary-btn:hover {
-  background: rgba(243, 187, 57, 0.18);
-  border-color: rgba(243, 187, 57, 0.68);
-}
-
-.settings-dark-panel .icon-btn {
-  border-color: #32415a;
-  background: #0d1522;
-  color: #c6d2e3;
-}
-
-.settings-dark-panel .icon-btn:hover {
-  background: #162237;
-  border-color: #4b5f81;
-  color: #f8fafc;
-}
-
-.settings-dark-panel .icon-btn:disabled {
-  opacity: 0.45;
-  cursor: default;
-}
-
 .settings-profile-panel {
-  background: #0a101a;
-  border-color: #1d2839;
-  color: #f8fafc;
-}
-
-.settings-profile-panel .panel-placeholder {
-  color: #8ea3be;
+  background: #fff;
+  border-color: var(--line);
+  color: var(--ink-900);
 }
 
 .settings-profile-panel .activity-list article {
-  border-color: #263247;
-  background: #111926;
+  border-color: var(--line);
+  background: #fffcf7;
 }
 
 .customer-name-cell {
@@ -1305,7 +1315,16 @@ a:focus-visible {
     grid-template-columns: 1fr;
   }
 
-  .settings-layout.has-profile {
+  .settings-tier-layout,
+  .settings-tier-layout.has-profile {
+    grid-template-columns: 1fr;
+  }
+
+  .settings-tier-nav {
+    position: static;
+  }
+
+  .settings-profile-content {
     grid-template-columns: 1fr;
   }
 


### PR DESCRIPTION
Closes #40

## What changed
- Reworked Settings into a tiered control-center IA with grouped navigation.
- Added `Platform Settings` sections:
  - `Profile` (current user overview + editable form shell)
  - `Users` (invite/manage users directly from settings, admin)
- Added `Manufacturing Settings` sections:
  - `Designers`
  - `Craftsmen`
  - `Steps`
  - `Fields`
- Kept designer/craftsman profile drill-down side panel for linked piece visibility.
- Shifted settings styling back to a light visual language aligned with current deployed pages.
- Reduced global visual scale (font/button/table sizing and some paddings) for a more compact UI.

## Validation
- `npm run build` in `frontend/` (passes; Vite prints local Node version warning but build succeeds)
